### PR TITLE
Add kubernetes client communicated with the Kubernetes API

### DIFF
--- a/assemble/src/main/kotlin/org/jaram/jubaky/module/KubernetesModule.kt
+++ b/assemble/src/main/kotlin/org/jaram/jubaky/module/KubernetesModule.kt
@@ -1,10 +1,19 @@
 package org.jaram.jubaky.module
 
+import org.jaram.jubaky.ext.getString
+import org.jaram.jubaky.kubernetes.KubernetesApi
 import org.jaram.jubaky.kubernetes.repository.KubernetesRepositoryImpl
 import org.jaram.jubaky.repository.KubernetesRepository
 import org.koin.dsl.module
 import org.koin.experimental.builder.singleBy
+import java.io.File
 
 val KubernetesModule = module {
+    single {
+        KubernetesApi(
+            File(getString("kubernetes.kubeconfig.path") ?: "")
+        )
+    }
+
     singleBy<KubernetesRepository, KubernetesRepositoryImpl>()
 }

--- a/assemble/src/main/kotlin/org/jaram/jubaky/module/ServiceModule.kt
+++ b/assemble/src/main/kotlin/org/jaram/jubaky/module/ServiceModule.kt
@@ -3,6 +3,7 @@ package org.jaram.jubaky.module
 import org.jaram.jubaky.ext.getInt
 import org.jaram.jubaky.ext.getString
 import org.jaram.jubaky.service.JenkinsService
+import org.jaram.jubaky.service.KubernetesService
 import org.jaram.jubaky.service.TokenService
 import org.jaram.jubaky.service.UserService
 import org.koin.dsl.module
@@ -11,6 +12,7 @@ import org.koin.experimental.builder.single
 val ServiceModule = module {
     single<UserService>()
     single<JenkinsService>()
+    single<KubernetesService>()
 
     single {
         TokenService(

--- a/assemble/src/main/resources/common.properties
+++ b/assemble/src/main/resources/common.properties
@@ -11,3 +11,5 @@ token.jubaky.validityInMs=36000000
 jenkins.url=
 jenkins.username=
 jenkins.token=
+
+kubernetes.kubeconfig.path=

--- a/base/src/main/kotlin/org/jaram/jubaky/exceptions.kt
+++ b/base/src/main/kotlin/org/jaram/jubaky/exceptions.kt
@@ -205,3 +205,45 @@ class JenkinsApiInternalServerException(cause: Throwable? = null) : ApiException
     messageEn = "Jenkins API internal server error has occurred.",
     cause = cause
 )
+
+// 200 ~ 299 : Kubernetes 오류
+fun createKubernetesApiException(message: String?, cause: Throwable? = null): ApiException {
+    val resultException: ApiException
+
+    when (message) {
+        "Conflict" -> resultException = KubernetesApiConflictException(cause)
+        "Bad Request" -> resultException = KubernetesApiBadRequestException(cause)
+        "Not Found" -> resultException = KubernetesApiNotFoundException(cause)
+        else -> resultException = KubernetesApiException(message ?: "Unknown", cause)
+    }
+
+    return resultException
+}
+
+class KubernetesApiException(message: String, cause: Throwable? = null) : ApiException(
+    code = 200,
+    messageKr = "쿠버네티스 API 에서 알 수 없는 오류가 발생하였습니다. (원인 : $message)",
+    messageEn = "Kubernetes API error has occurred. (Cause : $message)",
+    cause = cause
+)
+
+class KubernetesApiBadRequestException(cause: Throwable? = null) : ApiException(
+    code = 201,
+    messageKr = "쿠버네티스 API 에서 오류가 발생하였습니다. (원인 : Bad Request)",
+    messageEn = "Kubernetes API bad request error has occurred.",
+    cause = cause
+)
+
+class KubernetesApiNotFoundException(cause: Throwable? = null) : ApiException(
+    code = 204,
+    messageKr = "쿠버네티스 API 에서 오류가 발생하였습니다. (원인 : Not Found)",
+    messageEn = "Kubernetes API 'Not Found' error has occurred.",
+    cause = cause
+)
+
+class KubernetesApiConflictException(cause: Throwable? = null) : ApiException(
+    code = 205,
+    messageKr = "쿠버네티스 API 에서 오류가 발생하였습니다. (원인: Conflict)",
+    messageEn = "Kubernetes API conflict error has occurred.",
+    cause = cause
+)

--- a/domain/src/main/kotlin/org/jaram/jubaky/domain/Cluster.kt
+++ b/domain/src/main/kotlin/org/jaram/jubaky/domain/Cluster.kt
@@ -1,6 +1,0 @@
-package org.jaram.jubaky.domain
-
-data class Cluster(
-    val id: Int,
-    val name: String
-)

--- a/domain/src/main/kotlin/org/jaram/jubaky/domain/NameSpace.kt
+++ b/domain/src/main/kotlin/org/jaram/jubaky/domain/NameSpace.kt
@@ -1,5 +1,0 @@
-package org.jaram.jubaky.domain
-
-data class NameSpace(
-    val name: String
-)

--- a/domain/src/main/kotlin/org/jaram/jubaky/domain/Pipeline.kt
+++ b/domain/src/main/kotlin/org/jaram/jubaky/domain/Pipeline.kt
@@ -1,7 +1,0 @@
-package org.jaram.jubaky.domain
-
-data class Pipeline(
-    val id: Int,
-    val jenkinsId: String,
-    val name: String
-)

--- a/domain/src/main/kotlin/org/jaram/jubaky/domain/Pod.kt
+++ b/domain/src/main/kotlin/org/jaram/jubaky/domain/Pod.kt
@@ -1,6 +1,0 @@
-package org.jaram.jubaky.domain
-
-data class Pod(
-    val id: String,
-    val name: String
-)

--- a/domain/src/main/kotlin/org/jaram/jubaky/domain/kubernetes/Container.kt
+++ b/domain/src/main/kotlin/org/jaram/jubaky/domain/kubernetes/Container.kt
@@ -1,0 +1,67 @@
+package org.jaram.jubaky.domain.kubernetes
+
+import org.joda.time.DateTime
+
+data class Container(
+    val args: List<String>?,
+    val command: List<String>?,
+    val image: String?,
+    val name: String?,
+    val containerPorts: List<ContainerPort>?,
+    val resources: Resource?,
+    val terminationMessagePath: String?,
+    val terminationMessagePolicy: String?,
+    val tty: Boolean?,
+    val volumeDevices: List<Volume.VolumeDevice>?,
+    val volumeMounts: List<Volume.VolumeMount>?,
+    val workingDir: String?
+) {
+    data class ContainerPort(
+        val containerPort: Int?,
+        val hostIP: String?,
+        val hostPort: Int?,
+        val name: String?,
+        val protocol: String?
+    )
+
+    data class ContainerStatus(
+        val containerID: String?,
+        val image: String?,
+        val imageID: String?,
+        val lastState: ContainerState?,
+        val name: String?,
+        val ready: Boolean?,
+        val restartCount: Int?,
+        val state: ContainerState?
+    )
+
+    data class ContainerState(
+        val running: ContainerStateRunning?,
+        val terminated: ContainerStateTerminated?,
+        val waiting: ContainerStateWaiting?
+    ) {
+        data class ContainerStateRunning(
+            val startedAt: DateTime?
+        )
+
+        data class ContainerStateTerminated(
+            val containerID: String?,
+            val exitCode: Int?,
+            val finishedAt: DateTime?,
+            val message: String?,
+            val reason: String?,
+            val signal: Int?,
+            val startedAt: DateTime?
+        )
+
+        data class ContainerStateWaiting(
+            val message: String?,
+            val reason: String?
+        )
+    }
+
+    data class ContainerImage(
+        val names: List<String>?,
+        val sizeBytes: Long?
+    )
+}

--- a/domain/src/main/kotlin/org/jaram/jubaky/domain/kubernetes/DaemonSet.kt
+++ b/domain/src/main/kotlin/org/jaram/jubaky/domain/kubernetes/DaemonSet.kt
@@ -1,0 +1,46 @@
+package org.jaram.jubaky.domain.kubernetes
+
+data class DaemonSet(
+    val apiVersion: String?,
+    val kind: String?,
+    val metadata: Metadata?,
+    val spec: DaemonSetSpec?,
+    val status: DaemonSetStatus?
+) {
+    data class DaemonSetSpec(
+        val revisionHistoryLimit: Int?,
+        val selector: Selector?,
+        val template: PodTemplate.PodTemplateSpec?,
+        val templateGeneration: Long?,
+        val updateStrategy: DaemonSetUpdateStrategy?
+    )
+
+    data class DaemonSetStatus(
+        val collisionCount: Int?,
+        val conditions: List<DaemonSetCondition>?,
+        val currentNumberScheduled: Int?,
+        val desiredNumberScheduled: Int?,
+        val numberAvailable: Int?,
+        val numberMisscheduled: Int?,
+        val numberReady: Int?,
+        val numberUnavailable: Int?,
+        val observedGeneration: Long?,
+        val updatedNumberScheduled: Int?
+    )
+
+    data class DaemonSetCondition(
+        val message: String?,
+        val reason: String?,
+        val status: String?,
+        val type: String?
+    )
+
+    data class DaemonSetUpdateStrategy(
+        val rollingUpdate: DaemonSetRollingUpdate?,
+        val type: String?
+    )
+
+    data class DaemonSetRollingUpdate(
+        val maxUnavailable: Any?
+    )
+}

--- a/domain/src/main/kotlin/org/jaram/jubaky/domain/kubernetes/Deployment.kt
+++ b/domain/src/main/kotlin/org/jaram/jubaky/domain/kubernetes/Deployment.kt
@@ -1,0 +1,50 @@
+package org.jaram.jubaky.domain.kubernetes
+
+import org.joda.time.DateTime
+
+data class Deployment(
+    val apiVersion: String?,
+    val kind: String?,
+    val metadata: Metadata?,
+    val spec: DeploymentSpec?,
+    val status: DeploymentStatus?
+) {
+    data class DeploymentSpec(
+        val progressDeadlineSeconds: Int?,
+        val replicas: Int?,
+        val revisionHistoryLimit: Int?,
+        val selector: Selector?,
+        val strategy: DeploymentStrategy?,
+        val template: PodTemplate.PodTemplateSpec?
+    )
+
+    data class DeploymentStatus(
+        val availableReplicas: Int?,
+        val collisionCount: Int?,
+        val conditions: List<DeploymentCondition>?,
+        val observedGeneration: Long?,
+        val readyReplicas: Int?,
+        val replicas: Int?,
+        val unavailableReplicas: Int?,
+        val updatedReplicas: Int?
+    )
+
+    data class DeploymentStrategy(
+        val rollingUpdate: DeploymentRollingUpdate?,
+        val type: String?
+    )
+
+    data class DeploymentCondition(
+        val lastTransitionTime: DateTime?,
+        val lastUpdateTime: DateTime?,
+        val message: String?,
+        val reason: String?,
+        val status: String?,
+        val type: String?
+    )
+
+    data class DeploymentRollingUpdate(
+        val maxSurge: String?,
+        val maxUnavailable: String?
+    )
+}

--- a/domain/src/main/kotlin/org/jaram/jubaky/domain/kubernetes/Metadata.kt
+++ b/domain/src/main/kotlin/org/jaram/jubaky/domain/kubernetes/Metadata.kt
@@ -1,0 +1,39 @@
+package org.jaram.jubaky.domain.kubernetes
+
+import org.joda.time.DateTime
+
+data class Metadata(
+    val annotations: Map<String, String>?,
+    val clusterName: String?,
+    val creationTimestamp: DateTime?,
+    val deletionGracePeriodSeconds: Long?,
+    val deletionTimestamp: DateTime?,
+    val finalizers: List<String>?,
+    val generateName: String?,
+    val generation: Long?,
+    val initializers: Initializers?,
+    val labels: Map<String, String>?,
+    val name: String?,
+    val namespace: String?,
+    val ownerReference: List<OwnerReference>?,
+    val resourceVersion: String?,
+    val uid: String?
+) {
+    data class Initializers(
+        val pending: List<Initializer>?,
+        val result: Status?
+    ) {
+        data class Initializer(
+            val name: String?
+        )
+    }
+
+    data class OwnerReference(
+        val apiVersion: String?,
+        val blockOwnerDeletion: Boolean?,
+        val controller: Boolean?,
+        val kind: String?,
+        val name: String?,
+        val uid: String?
+    )
+}

--- a/domain/src/main/kotlin/org/jaram/jubaky/domain/kubernetes/Namespace.kt
+++ b/domain/src/main/kotlin/org/jaram/jubaky/domain/kubernetes/Namespace.kt
@@ -1,0 +1,17 @@
+package org.jaram.jubaky.domain.kubernetes
+
+data class Namespace(
+    val apiVersion: String?,
+    val kind: String?,
+    val metadata: Metadata?,
+    val spec: NamespaceSpec?,
+    val status: NamespaceStatus?
+) {
+    data class NamespaceSpec(
+        val finalizers: List<String>?
+    )
+
+    data class NamespaceStatus(
+        val phase: String?
+    )
+}

--- a/domain/src/main/kotlin/org/jaram/jubaky/domain/kubernetes/Node.kt
+++ b/domain/src/main/kotlin/org/jaram/jubaky/domain/kubernetes/Node.kt
@@ -1,0 +1,78 @@
+package org.jaram.jubaky.domain.kubernetes
+
+import org.joda.time.DateTime
+
+data class Node(
+    val apiVersion: String?,
+    val kind: String?,
+    val metadata: Metadata?,
+    val spec: NodeSpec?,
+    val status: NodeStatus?
+) {
+    data class NodeSpec(
+        val configSource: NodeConfigSource?,
+        val externalID: String?,
+        val podCIDR: String?,
+        val providerID: String?,
+        val taints: List<Taint>?,
+        val unschedulable: Boolean?
+    )
+
+    data class NodeStatus(
+        val addresses: List<NodeAddress>?,
+        val allocatable: Map<String, Resource.Quantity>?,
+        val capacity: Map<String, Resource.Quantity>?,
+        val conditions: List<NodeCondition>?,
+        val daemonEndpoints: NodeDaemonEndpoints?,
+        val images: List<Container.ContainerImage>?,
+        val nodeInfo: NodeSystemInfo?,
+        val phase: String?
+    )
+
+    data class NodeConfigSource(
+        val configMap: ConfigMapNodeConfigSource?
+    )
+
+    data class ConfigMapNodeConfigSource(
+        val kubeletConfigKey: String?,
+        val name: String?,
+        val namespace: String?,
+        val resourceVersion: String?,
+        val uid: String?
+    )
+
+    data class NodeAddress(
+        val address: String?,
+        val type: String?
+    )
+
+    data class NodeCondition(
+        val lastHeartbeatTime: DateTime?,
+        val lastTransitionTime: DateTime?,
+        val message: String?,
+        val reason: String?,
+        val status: String?,
+        val type: String?
+    )
+
+    data class NodeDaemonEndpoints(
+        val kubeletEndpoint: DaemonEndpoint?
+    )
+
+    data class DaemonEndpoint(
+        val Port: Int?
+    )
+
+    data class NodeSystemInfo(
+        val architecture: String?,
+        val bootID: String?,
+        val containerRuntimeVersion: String?,
+        val kernelVersion: String?,
+        val kubeProxyVersion: String?,
+        val kubeletVersion: String?,
+        val machineID: String?,
+        val operatingSystem: String?,
+        val osImage: String?,
+        val systemUUID: String?
+    )
+}

--- a/domain/src/main/kotlin/org/jaram/jubaky/domain/kubernetes/PersistentVolumeClaim.kt
+++ b/domain/src/main/kotlin/org/jaram/jubaky/domain/kubernetes/PersistentVolumeClaim.kt
@@ -1,0 +1,43 @@
+package org.jaram.jubaky.domain.kubernetes
+
+import org.joda.time.DateTime
+
+data class PersistentVolumeClaim(
+    val apiVersion: String?,
+    val kind: String?,
+    val metadata: Metadata?,
+    val spec: PersistentVolumeClaimSpec?,
+    val status: PersistentVolumeClaimStatus?
+) {
+    data class PersistentVolumeClaimSpec(
+        val accessModes: List<String>?,
+        val dataSource: TypedLocalObjectReference?,
+        val resources: Resource?,
+        val selector: Selector?,
+        val storageClassName: String?,
+        val volumeMode: String?,
+        val volumeName: String?
+    )
+
+    data class PersistentVolumeClaimStatus(
+        val accessModes: List<String>?,
+        val capacity: Map<String, Resource.Quantity>?,
+        val conditions: List<PersistentVolumeClaimCondition>?,
+        val phase: String?
+    )
+
+    data class TypedLocalObjectReference(
+        val apiGroup: String?,
+        val kind: String?,
+        val name: String?
+    )
+
+    data class PersistentVolumeClaimCondition(
+        val lastProbeTime: DateTime?,
+        val lastTransitionTime: DateTime?,
+        val message: String?,
+        val reason: String?,
+        val status: String?,
+        val type: String?
+    )
+}

--- a/domain/src/main/kotlin/org/jaram/jubaky/domain/kubernetes/Pod.kt
+++ b/domain/src/main/kotlin/org/jaram/jubaky/domain/kubernetes/Pod.kt
@@ -1,0 +1,98 @@
+package org.jaram.jubaky.domain.kubernetes
+
+import org.joda.time.DateTime
+
+data class Pod(
+    val apiVersion: String?,
+    val kind: String?,
+    val metadata: Metadata?,
+    val spec: PodSpec?,
+    val status: PodStatus?
+) {
+    data class PodSpec(
+//        val activeDeadlineSeconds?,
+//        val affinity?,
+//        val automountServiceAccountToken?,
+        val containers: List<Container>?,
+        val dnsConfig: PodDNSConfig?,
+        val dnsPolicy: String?,
+        val enableServiceLinks: Boolean?,
+        val hostAliases: List<HostAlias>?,
+        val hostIPC: Boolean?,
+        val hostNetwork: Boolean?,
+        val hostPID: Boolean?,
+        val hostname: String?,
+//        val imagePullSecrets?,
+        val initContainers: List<Container>?,
+        val nodeName: String?,
+        val nodeSelector: Map<String, String>?,
+        val priority: Int?,
+        val priorityClassName: String?,
+//        val readinessGates?,
+        val restartPolicy: String?,
+//        val runtimeClassName?,
+        val schedulerName: String?,
+        val securityContext: PodSecurityContext?,
+        val serviceAccount: String?,
+        val serviceAccountName: String?,
+        val shareProcessNamespace: Boolean?,
+        val subdomain: String?,
+        val terminationGracePeriodSeconds: Long?,
+        val tolerations: List<Toleration>?,
+        val volumes: List<Volume>?
+    )
+
+    data class PodStatus(
+        val conditions: List<PodCondition>?,
+        val containerStatuses: List<Container.ContainerStatus>?,
+        val hostIP: String?,
+        val initContainerStatuses: List<Container.ContainerStatus>?,
+        val message: String?,
+        val nominatedNodeName: String?,
+        val phase: String?,
+        val podIP: String?,
+        val qosClass: String?,
+        val reason: String?,
+        val startTime: DateTime?
+    )
+
+    data class PodDNSConfig(
+        val nameservers: List<String>?,
+        val options: List<PodDNSConfigOption>?,
+        val searches: List<String>?
+    )
+
+    data class PodDNSConfigOption(
+        val name: String?,
+        val value: String?
+    )
+
+    data class PodSecurityContext(
+        val fsGroup: Long?,
+        val runAsGroup: Long?,
+        val runAsNonRoot: Boolean?,
+        val runAsUser: Long?
+    )
+
+    data class HostAlias(
+        val hostnames: List<String>?,
+        val ip: String?
+    )
+
+    data class Toleration(
+        val effect: String?,
+        val key: String?,
+        val operator: String?,
+        val tolerationSeconds: Long?,
+        val value: String?
+    )
+
+    data class PodCondition(
+        val lastProbeTime: DateTime?,
+        val lastTransitionTime: DateTime?,
+        val message: String?,
+        val reason: String?,
+        val status: String?,
+        val type: String?
+    )
+}

--- a/domain/src/main/kotlin/org/jaram/jubaky/domain/kubernetes/PodTemplate.kt
+++ b/domain/src/main/kotlin/org/jaram/jubaky/domain/kubernetes/PodTemplate.kt
@@ -1,0 +1,10 @@
+package org.jaram.jubaky.domain.kubernetes
+
+data class PodTemplate(
+    val uid: String?
+) {
+    data class PodTemplateSpec(
+        val metadata: Metadata?,
+        val spec: Pod.PodSpec?
+    )
+}

--- a/domain/src/main/kotlin/org/jaram/jubaky/domain/kubernetes/ReplicaSet.kt
+++ b/domain/src/main/kotlin/org/jaram/jubaky/domain/kubernetes/ReplicaSet.kt
@@ -1,0 +1,35 @@
+package org.jaram.jubaky.domain.kubernetes
+
+import org.joda.time.DateTime
+
+data class ReplicaSet(
+    val apiVersion: String?,
+    val kind: String?,
+    val metadata: Metadata?,
+    val spec: ReplicaSetSpec?,
+    val status: ReplicaSetStatus?
+) {
+    data class ReplicaSetSpec(
+        val minReadySeconds: Int?,
+        val replicas: Int?,
+        val selector: Selector?,
+        val template: PodTemplate.PodTemplateSpec?
+    )
+
+    data class ReplicaSetStatus(
+        val availableReplicas: Int?,
+        val conditions: List<ReplicaSetCondition>?,
+        val fullyLabeledReplicas: Int?,
+        val observedGeneration: Long?,
+        val readyReplicas: Int?,
+        val replicas: Int?
+    )
+
+    data class ReplicaSetCondition(
+        val lastTransitionTime: DateTime?,
+        val message: String?,
+        val reason: String?,
+        val status: String?,
+        val type: String?
+    )
+}

--- a/domain/src/main/kotlin/org/jaram/jubaky/domain/kubernetes/Resource.kt
+++ b/domain/src/main/kotlin/org/jaram/jubaky/domain/kubernetes/Resource.kt
@@ -1,0 +1,13 @@
+package org.jaram.jubaky.domain.kubernetes
+
+import java.math.BigDecimal
+
+data class Resource(
+    val limits: Map<String, Quantity>?,
+    val requests: Map<String, Quantity>?
+) {
+    data class Quantity(
+        val number: BigDecimal?,
+        val format: Int?
+    )
+}

--- a/domain/src/main/kotlin/org/jaram/jubaky/domain/kubernetes/Secret.kt
+++ b/domain/src/main/kotlin/org/jaram/jubaky/domain/kubernetes/Secret.kt
@@ -1,0 +1,10 @@
+package org.jaram.jubaky.domain.kubernetes
+
+data class Secret(
+    val apiVersion: String?,
+    val data: Map<String, ByteArray>?,
+    val kind: String?,
+    val metadata: Metadata?,
+    val stringData: Map<String, String>?,
+    val type: String?
+)

--- a/domain/src/main/kotlin/org/jaram/jubaky/domain/kubernetes/Selector.kt
+++ b/domain/src/main/kotlin/org/jaram/jubaky/domain/kubernetes/Selector.kt
@@ -1,0 +1,12 @@
+package org.jaram.jubaky.domain.kubernetes
+
+data class Selector(
+    val matchExpressions: List<SelectorRequirements>?,
+    val matchLabels: Map<String, String>?
+) {
+    data class SelectorRequirements(
+        val key: String?,
+        val operator: String?,
+        val values: List<String>?
+    )
+}

--- a/domain/src/main/kotlin/org/jaram/jubaky/domain/kubernetes/Service.kt
+++ b/domain/src/main/kotlin/org/jaram/jubaky/domain/kubernetes/Service.kt
@@ -1,0 +1,54 @@
+package org.jaram.jubaky.domain.kubernetes
+
+data class Service(
+    val apiVersion: String?,
+    val kind: String?,
+    val metadata: Metadata?,
+    val spec: ServiceSpec?,
+    val status: ServiceStatus?
+) {
+    data class ServiceSpec(
+        val clusterIP: String?,
+        val externalIPs: List<String>?,
+        val externalName: String?,
+        val externalTrafficPolicy: String?,
+        val healthCheckNodePort: Int?,
+        val loadBalancerIP: String?,
+        val loadBalancerSourceRanges: List<String>?,
+        val ports: List<ServicePort>?,
+        val publishNotReadyAddresses: Boolean?,
+        val selector: Map<String, String>?,
+        val sessionAffinity: String?,
+        val sessionAffinityConfig: SessionAffinityConfig?,
+        val type: String?
+    )
+
+    data class ServiceStatus(
+        val loadBalancer: LoadBalancerStatus?
+    )
+
+    data class ServicePort(
+        val name: String?,
+        val nodePort: Int?,
+        val port: Int?,
+        val protocol: String?,
+        val targetPort: Any?
+    )
+
+    data class SessionAffinityConfig(
+        val clientIP: ClientIPConfig?
+    )
+
+    data class LoadBalancerStatus(
+        val ingress: List<LoadBalancerIngress>?
+    )
+
+    data class LoadBalancerIngress(
+        val hostname: String?,
+        val ip: String?
+    )
+
+    data class ClientIPConfig(
+        val timeoutSeconds: Int?
+    )
+}

--- a/domain/src/main/kotlin/org/jaram/jubaky/domain/kubernetes/StatefulSet.kt
+++ b/domain/src/main/kotlin/org/jaram/jubaky/domain/kubernetes/StatefulSet.kt
@@ -1,0 +1,51 @@
+package org.jaram.jubaky.domain.kubernetes
+
+import org.joda.time.DateTime
+
+data class StatefulSet(
+    val apiVersion: String?,
+    val kind: String?,
+    val metadata: Metadata?,
+    val spec: StatefulSetSpec?,
+    val status: StatefulSetStatus?
+) {
+    data class StatefulSetSpec(
+        val podManagementPolicy: String?,
+        val replicas: Int?,
+        val revisionHistoryLimit: Int?,
+        val selector: Selector?,
+        val serviceName: String?,
+        val template: PodTemplate.PodTemplateSpec?,
+        val updateStrategy: StatefulSetUpdateStrategy?,
+        val volumeClaimTemplates: List<PersistentVolumeClaim>?
+    )
+
+    data class StatefulSetStatus(
+        val collisionCount: Int?,
+        val conditions: List<StatefulSetCondition>?,
+        val currentReplicas: Int?,
+        val currentRevision: String?,
+        val observedGeneration: Long?,
+        val readyReplicas: Int?,
+        val replicas: Int?,
+        val updateRevision: String?,
+        val updatedReplicas: Int?
+    )
+
+    data class StatefulSetUpdateStrategy(
+        val rollingUpdate: RollingUpdateStatefulSetStrategy?,
+        val type: String?
+    )
+
+    data class RollingUpdateStatefulSetStrategy(
+        val partition: Int?
+    )
+
+    data class StatefulSetCondition(
+        val lastTransitionTime: DateTime?,
+        val message: String?,
+        val reason: String?,
+        val status: String?,
+        val type: String?
+    )
+}

--- a/domain/src/main/kotlin/org/jaram/jubaky/domain/kubernetes/Status.kt
+++ b/domain/src/main/kotlin/org/jaram/jubaky/domain/kubernetes/Status.kt
@@ -1,0 +1,33 @@
+package org.jaram.jubaky.domain.kubernetes
+
+data class Status(
+    val apiVersion: String?,
+    val code: Int?,
+    val details: StatusDetails?,
+    val kind: String?,
+    val message: String?,
+    val metadata: ListMeta?,
+    val reason: String?,
+    val status: String?
+) {
+    data class StatusDetails(
+        val causes: List<StatusCause>?,
+        val group: String?,
+        val kind: String?,
+        val name: String?,
+        val retryAfterSeconds: Int?,
+        val uid: String?
+    )
+
+    data class ListMeta(
+        val _continue: String?,
+        val resourceVersion: String?,
+        val selfLink: String?
+    )
+
+    data class StatusCause(
+        val field: String?,
+        val message: String?,
+        val reason: String?
+    )
+}

--- a/domain/src/main/kotlin/org/jaram/jubaky/domain/kubernetes/Taint.kt
+++ b/domain/src/main/kotlin/org/jaram/jubaky/domain/kubernetes/Taint.kt
@@ -1,0 +1,10 @@
+package org.jaram.jubaky.domain.kubernetes
+
+import org.joda.time.DateTime
+
+data class Taint(
+    val effect: String?,
+    val key: String?,
+    val timeAdded: DateTime?,
+    val value: String?
+)

--- a/domain/src/main/kotlin/org/jaram/jubaky/domain/kubernetes/Volume.kt
+++ b/domain/src/main/kotlin/org/jaram/jubaky/domain/kubernetes/Volume.kt
@@ -1,0 +1,24 @@
+package org.jaram.jubaky.domain.kubernetes
+
+data class Volume(
+    val name: String?,
+    val hostPath: HostPathVolumeSource?
+) {
+    data class VolumeDevice(
+        val devicePath: String?,
+        val name: String?
+    )
+
+    data class VolumeMount(
+        val mountPath: String?,
+        val mountPropagation: String?,
+        val name: String?,
+        val readOnly: Boolean?,
+        val subPath: String?
+    )
+
+    data class HostPathVolumeSource(
+        val path: String?,
+        val type: String?
+    )
+}

--- a/domain/src/main/kotlin/org/jaram/jubaky/repository/KubernetesRepository.kt
+++ b/domain/src/main/kotlin/org/jaram/jubaky/repository/KubernetesRepository.kt
@@ -1,13 +1,92 @@
 package org.jaram.jubaky.repository
 
-import org.jaram.jubaky.domain.NameSpace
-import org.jaram.jubaky.domain.Pod
+import org.jaram.jubaky.domain.kubernetes.*
 
 interface KubernetesRepository {
 
-    suspend fun getNameSpaceList(): List<NameSpace>
+    suspend fun getDaemonSet(daemonSetName: String, namespace: String): DaemonSet
 
-    suspend fun getPodList(nameSpace: NameSpace? = null): List<Pod>
+    suspend fun getDaemonSetList(namespace: String? = null): List<DaemonSet>
 
-    suspend fun getPod(nameSpace: NameSpace, podName: String): Pod
+    suspend fun createDaemonSet(yaml: String, namespace: String): DaemonSet
+
+    suspend fun replaceDaemonSet(name: String, yaml: String, namespace: String): DaemonSet
+
+    suspend fun deleteDaemonSet(daemonSetName: String, namespace: String)
+
+    suspend fun getDeployment(deploymentName: String, namespace: String): Deployment
+
+    suspend fun getDeploymentList(namespace: String? = null): List<Deployment>
+
+    suspend fun createDeployment(yaml: String, namespace: String): Deployment
+
+    suspend fun replaceDeployment(name: String, yaml: String, namespace: String): Deployment
+
+    suspend fun deleteDeployment(deploymentName: String, namespace: String)
+
+    suspend fun getNamespace(namespaceName: String): Namespace
+
+    suspend fun getNamespaceList(): List<Namespace>
+
+    suspend fun createNamespace(yaml: String): Namespace
+
+    suspend fun replaceNamespace(name: String, yaml: String): Namespace
+
+    suspend fun deleteNamespace(namespaceName: String)
+
+    suspend fun getNode(nodeName: String): Node
+
+    suspend fun getNodeList(): List<Node>
+
+    suspend fun deleteNode(nodeName: String)
+
+    suspend fun getPod(podName: String, namespace: String): Pod
+
+    suspend fun getPodList(namespace: String? = null): List<Pod>
+
+    suspend fun createPod(yaml: String, namespace: String): Pod
+
+    suspend fun replacePod(name: String, yaml: String, namespace: String): Pod
+
+    suspend fun deletePod(podName: String, namespace: String)
+
+    suspend fun getReplicaSet(replicaSetName: String, namespace: String): ReplicaSet
+
+    suspend fun getReplicaSetList(namespace: String? = null): List<ReplicaSet>
+
+    suspend fun createReplicaSet(yaml: String, namespace: String): ReplicaSet
+
+    suspend fun replaceReplicaSet(name: String, yaml: String, namespace: String): ReplicaSet
+
+    suspend fun deleteReplicaSet(replicaSetName: String, namespace: String)
+
+    suspend fun getSecret(secretName: String, namespace: String): Secret
+
+    suspend fun getSecretList(namespace: String? = null): List<Secret>
+
+    suspend fun createSecret(yaml: String, namespace: String): Secret
+
+    suspend fun replaceSecret(name: String, yaml: String, namespace: String): Secret
+
+    suspend fun deleteSecret(secretName: String, namespace: String)
+
+    suspend fun getService(serviceName: String, namespace: String): Service
+
+    suspend fun getServiceList(namespace: String? = null): List<Service>
+
+    suspend fun createService(yaml: String, namespace: String): Service
+
+    suspend fun replaceService(name: String, yaml: String, namespace: String): Service
+
+    suspend fun deleteService(serviceName: String, namespace: String)
+
+    suspend fun getStatefulSet(statefulSetName: String, namespace: String): StatefulSet
+
+    suspend fun getStatefulSetList(namespace: String? = null): List<StatefulSet>
+
+    suspend fun createStatefulSet(yaml: String, namespace: String): StatefulSet
+
+    suspend fun replaceStatefulSet(name: String, yaml: String, namespace: String): StatefulSet
+
+    suspend fun deleteStatefulSet(statefulSetName: String, namespace: String)
 }

--- a/domain/src/main/kotlin/org/jaram/jubaky/service/KubernetesService.kt
+++ b/domain/src/main/kotlin/org/jaram/jubaky/service/KubernetesService.kt
@@ -1,0 +1,181 @@
+package org.jaram.jubaky.service
+
+import org.jaram.jubaky.domain.kubernetes.*
+import org.jaram.jubaky.repository.KubernetesRepository
+
+class KubernetesService(
+    private val kubernetesRepository: KubernetesRepository
+) {
+
+    suspend fun getDaemonSet(daemonSetName: String, namespace: String): DaemonSet {
+        return kubernetesRepository.getDaemonSet(daemonSetName, namespace)
+    }
+
+    suspend fun getDaemonSetList(namespace: String? = null): List<DaemonSet> {
+        return kubernetesRepository.getDaemonSetList(namespace)
+    }
+
+    suspend fun createDaemonSet(yaml: String, namespace: String): DaemonSet {
+        return kubernetesRepository.createDaemonSet(yaml, namespace)
+    }
+
+    suspend fun replaceDaemonSet(name: String, yaml: String, namespace: String): DaemonSet {
+        return kubernetesRepository.replaceDaemonSet(name, yaml, namespace)
+    }
+
+    suspend fun deleteDaemonSet(daemonSetName: String, namespace: String) {
+        return kubernetesRepository.deleteDaemonSet(daemonSetName, namespace)
+    }
+
+    suspend fun getDeployment(deploymentName: String, namespace: String): Deployment {
+        return kubernetesRepository.getDeployment(deploymentName, namespace)
+    }
+
+    suspend fun getDeploymentList(namespace: String? = null): List<Deployment> {
+        return kubernetesRepository.getDeploymentList(namespace)
+    }
+
+    suspend fun createDeployment(yaml: String, namespace: String): Deployment {
+        return kubernetesRepository.createDeployment(yaml, namespace)
+    }
+
+    suspend fun replaceDeployment(name: String, yaml: String, namespace: String): Deployment {
+        return kubernetesRepository.replaceDeployment(name, yaml, namespace)
+    }
+
+    suspend fun deleteDeployment(deploymentName: String, namespace: String) {
+        return kubernetesRepository.deleteDeployment(deploymentName, namespace)
+    }
+
+    suspend fun getNamespace(namespaceName: String): Namespace {
+        return kubernetesRepository.getNamespace(namespaceName)
+    }
+
+    suspend fun getNamespaceList(): List<Namespace> {
+        return kubernetesRepository.getNamespaceList()
+    }
+
+    suspend fun createNamespace(yaml: String): Namespace {
+        return kubernetesRepository.createNamespace(yaml)
+    }
+
+    suspend fun replaceNamespace(name: String, yaml: String): Namespace {
+        return kubernetesRepository.replaceNamespace(name, yaml)
+    }
+
+    suspend fun deleteNamespace(namespaceName: String) {
+        return kubernetesRepository.deleteNamespace(namespaceName)
+    }
+
+    suspend fun getNode(nodeName: String): Node {
+        return kubernetesRepository.getNode(nodeName)
+    }
+
+    suspend fun getNodeList(): List<Node> {
+        return kubernetesRepository.getNodeList()
+    }
+
+    suspend fun deleteNode(nodeName: String) {
+        return kubernetesRepository.deleteNode(nodeName)
+    }
+
+    suspend fun getPod(podName: String, namespace: String): Pod {
+        return kubernetesRepository.getPod(podName, namespace)
+    }
+
+    suspend fun getPodList(namespace: String? = null): List<Pod> {
+        return kubernetesRepository.getPodList(namespace)
+    }
+
+    suspend fun createPod(yaml: String, namespace: String): Pod {
+        return kubernetesRepository.createPod(yaml, namespace)
+    }
+
+    suspend fun replacePod(name: String, yaml: String, namespace: String): Pod {
+        return kubernetesRepository.replacePod(name, yaml, namespace)
+    }
+
+    suspend fun deletePod(podName: String, namespace: String) {
+        return kubernetesRepository.deletePod(podName, namespace)
+    }
+
+    suspend fun getReplicaSet(replicaSetName: String, namespace: String): ReplicaSet {
+        return kubernetesRepository.getReplicaSet(replicaSetName, namespace)
+    }
+
+    suspend fun getReplicaSetList(namespace: String? = null): List<ReplicaSet> {
+        return kubernetesRepository.getReplicaSetList(namespace)
+    }
+
+    suspend fun createReplicaSet(yaml: String, namespace: String): ReplicaSet {
+        return kubernetesRepository.createReplicaSet(yaml, namespace)
+    }
+
+    suspend fun replaceReplicaSet(name: String, yaml: String, namespace: String): ReplicaSet {
+        return kubernetesRepository.replaceReplicaSet(name, yaml, namespace)
+    }
+
+    suspend fun deleteReplicaSet(replicaSetName: String, namespace: String) {
+        return kubernetesRepository.deleteReplicaSet(replicaSetName, namespace)
+    }
+
+    suspend fun getSecret(secretName: String, namespace: String): Secret {
+        return kubernetesRepository.getSecret(secretName, namespace)
+    }
+
+    suspend fun getSecretList(namespace: String? = null): List<Secret> {
+        return kubernetesRepository.getSecretList(namespace)
+    }
+
+    suspend fun createSecret(yaml: String, namespace: String): Secret {
+        return kubernetesRepository.createSecret(yaml, namespace)
+    }
+
+    suspend fun replaceSecret(name: String, yaml: String, namespace: String): Secret {
+        return kubernetesRepository.replaceSecret(name, yaml, namespace)
+    }
+
+    suspend fun deleteSecret(secretName: String, namespace: String) {
+        return kubernetesRepository.deleteSecret(secretName, namespace)
+    }
+
+    suspend fun getService(serviceName: String, namespace: String): Service {
+        return kubernetesRepository.getService(serviceName, namespace)
+    }
+
+    suspend fun getServiceList(namespace: String? = null): List<Service> {
+        return kubernetesRepository.getServiceList(namespace)
+    }
+
+    suspend fun createService(yaml: String, namespace: String): Service {
+        return kubernetesRepository.createService(yaml, namespace)
+    }
+
+    suspend fun replaceService(name: String, yaml: String, namespace: String): Service {
+        return kubernetesRepository.replaceService(name, yaml, namespace)
+    }
+
+    suspend fun deleteService(serviceName: String, namespace: String) {
+        return kubernetesRepository.deleteService(serviceName, namespace)
+    }
+
+    suspend fun getStatefulSet(statefulSetName: String, namespace: String): StatefulSet {
+        return kubernetesRepository.getStatefulSet(statefulSetName, namespace)
+    }
+
+    suspend fun getStatefulSetList(namespace: String? = null): List<StatefulSet> {
+        return kubernetesRepository.getStatefulSetList(namespace)
+    }
+
+    suspend fun createStatefulSet(yaml: String, namespace: String): StatefulSet {
+        return kubernetesRepository.createStatefulSet(yaml, namespace)
+    }
+
+    suspend fun replaceStatefulSet(name: String, yaml: String, namespace: String): StatefulSet {
+        return kubernetesRepository.replaceStatefulSet(name, yaml, namespace)
+    }
+
+    suspend fun deleteStatefulSet(statefulSetName: String, namespace: String) {
+        return kubernetesRepository.deleteStatefulSet(statefulSetName, namespace)
+    }
+}

--- a/kubernetes/src/main/kotlin/org/jaram/jubaky/kubernetes/KubernetesApi.kt
+++ b/kubernetes/src/main/kotlin/org/jaram/jubaky/kubernetes/KubernetesApi.kt
@@ -1,16 +1,22 @@
 package org.jaram.jubaky.kubernetes
 
 import io.kubernetes.client.ApiClient
+import io.kubernetes.client.ProgressRequestBody
+import io.kubernetes.client.ProgressResponseBody
+import io.kubernetes.client.apis.AppsV1Api
 import io.kubernetes.client.apis.CoreV1Api
-import io.kubernetes.client.models.V1Namespace
-import io.kubernetes.client.models.V1Pod
+import io.kubernetes.client.apis.ExtensionsV1beta1Api
+import io.kubernetes.client.models.*
 import io.kubernetes.client.util.Config
+import org.jaram.jubaky.createKubernetesApiException
 import java.io.File
 
-class KubernetesApi(configFile: File) {
+open class KubernetesApi(configFile: File)  {
 
     private val client: ApiClient
-    private val api: CoreV1Api
+    private val coreV1Api: CoreV1Api
+    private val appsV1Api: AppsV1Api
+    private val extV1beta1Api: ExtensionsV1beta1Api
 
     init {
         val inputStream = configFile.inputStream()
@@ -19,53 +25,968 @@ class KubernetesApi(configFile: File) {
 
         inputStream.close()
 
-        api = CoreV1Api(client)
+        coreV1Api = CoreV1Api(client)
+        appsV1Api = AppsV1Api(client)
+        extV1beta1Api = ExtensionsV1beta1Api(client)
     }
 
-    fun getNameSpaceList(): List<V1Namespace> {
-        return api.listNamespace(
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null
-        ).items
-    }
-
-    fun getPodList(nameSpace: String? = null): List<V1Pod> {
-        if (nameSpace.isNullOrBlank()) {
-            return api.listPodForAllNamespaces(
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-            ).items
+    fun getDaemonSet(
+        daemonSetName: String,
+        namespace: String? = "default",
+        pretty: String? = null,
+        exact: Boolean? = null,
+        export: Boolean? = null
+    ): V1beta1DaemonSet {
+        try {
+            return extV1beta1Api.readNamespacedDaemonSet(daemonSetName, namespace, pretty, exact, export)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
         }
-
-        return api.listNamespacedPod(
-            nameSpace,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null
-        ).items
     }
 
-    fun getPod(nameSpace: String, podName: String): V1Pod {
-        return api.readNamespacedPod(podName, nameSpace, null, null, null)
+    fun getDaemonSetList(
+        namespace: String? = "default",
+        includeUninitialized: Boolean? = null,
+        pretty: String? = null,
+        _continue: String? = null,
+        fieldSelector: String? = null,
+        labelSelector: String? = null,
+        limit: Int? = null,
+        resourceVersion: String? = null,
+        timeoutSeconds: Int? = null,
+        watch: Boolean? = null
+    ): V1beta1DaemonSetList {
+        try {
+            return extV1beta1Api.listNamespacedDaemonSet(namespace, includeUninitialized, pretty, _continue, fieldSelector, labelSelector, limit, resourceVersion, timeoutSeconds, watch)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun getDaemonSetListForAllNamespaces(
+        _continue: String? = null,
+        fieldSelector: String? = null,
+        includeUninitialized: Boolean? = null,
+        labelSelector: String? = null,
+        limit: Int? = null,
+        pretty: String? = null,
+        resourceVersion: String? = null,
+        timeoutSeconds: Int? = null,
+        watch: Boolean? = null
+    ): V1beta1DaemonSetList {
+        try {
+            return extV1beta1Api.listDaemonSetForAllNamespaces(_continue, fieldSelector, includeUninitialized, labelSelector, limit, pretty, resourceVersion, timeoutSeconds, watch)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun createDaemonSet(
+        namespace: String? = "default",
+        daemonSet: V1beta1DaemonSet,
+        includeUninitialized: Boolean? = null,
+        pretty: String? = null,
+        dryRun: String? = null
+    ): V1beta1DaemonSet {
+        try {
+            return extV1beta1Api.createNamespacedDaemonSet(namespace, daemonSet, includeUninitialized, pretty, dryRun)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun replaceDaemonSet(
+        daemonSetName: String,
+        namespace: String? = "default",
+        daemonSet: V1beta1DaemonSet,
+        pretty: String? = null,
+        dryRun: String? = null
+    ): V1beta1DaemonSet {
+        try {
+            return extV1beta1Api.replaceNamespacedDaemonSet(daemonSetName, namespace, daemonSet, pretty, dryRun)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun patchDaemonSet(
+        daemonSetName: String,
+        namespace: String? = "default",
+        daemonSet: Any,
+        pretty: String? = null,
+        dryRun: String? = null
+    ): V1beta1DaemonSet {
+        try {
+            return extV1beta1Api.patchNamespacedDaemonSet(daemonSetName, namespace, daemonSet, pretty, dryRun)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun deleteDaemonSet(
+        daemonSetName: String,
+        namespace: String? = "default",
+        pretty: String? = null,
+        deleteOptions: V1DeleteOptions? = null,
+        dryRun: String? = null,
+        gracePeriodSeconds: Int? = null,
+        orphanDependents: Boolean? = null,
+        propagationPolicy: String? = null,
+        progressListener: ProgressResponseBody.ProgressListener? = null,
+        progressRequestListener: ProgressRequestBody.ProgressRequestListener? = null
+    ) {
+        val response = extV1beta1Api.deleteNamespacedDaemonSetCall(daemonSetName, namespace, pretty, deleteOptions, dryRun, gracePeriodSeconds, orphanDependents, propagationPolicy, progressListener, progressRequestListener).execute()
+
+        if (!response.isSuccessful) {
+            throw createKubernetesApiException(response.message())
+        }
+    }
+
+    fun getDeployment(
+        deploymentName: String,
+        namespace: String? = "default",
+        pretty: String? = null,
+        exact: Boolean? = null,
+        export: Boolean? = null
+    ): ExtensionsV1beta1Deployment {
+        try {
+            return extV1beta1Api.readNamespacedDeployment(deploymentName, namespace, pretty, exact, export)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun getDeploymentList(
+        namespace: String? = "default",
+        includeUninitialized: Boolean? = null,
+        pretty: String? = null,
+        _continue: String? = null,
+        fieldSelector: String? = null,
+        labelSelector: String? = null,
+        limit: Int? = null,
+        resourceVersion: String? = null,
+        timeoutSeconds: Int? = null,
+        watch: Boolean? = null
+    ): ExtensionsV1beta1DeploymentList {
+        try {
+            return extV1beta1Api.listNamespacedDeployment(namespace, includeUninitialized, pretty, _continue, fieldSelector, labelSelector, limit, resourceVersion, timeoutSeconds, watch)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun getDeploymentListForAllNamespaces(
+        _continue: String? = null,
+        fieldSelector: String? = null,
+        includeUninitialized: Boolean? = null,
+        labelSelector: String? = null,
+        limit: Int? = null,
+        pretty: String? = null,
+        resourceVersion: String? = null,
+        timeoutSeconds: Int? = null,
+        watch: Boolean? = null
+    ): ExtensionsV1beta1DeploymentList {
+        try {
+            return extV1beta1Api.listDeploymentForAllNamespaces(_continue, fieldSelector, includeUninitialized, labelSelector, limit, pretty, resourceVersion, timeoutSeconds, watch)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun createDeployment(
+        namespace: String? = "default",
+        deployment: ExtensionsV1beta1Deployment,
+        includeUninitialized: Boolean? = null,
+        pretty: String? = null,
+        dryRun: String? = null
+    ): ExtensionsV1beta1Deployment {
+        try {
+            return extV1beta1Api.createNamespacedDeployment(namespace, deployment, includeUninitialized, pretty, dryRun)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun replaceDeployment(
+        deploymentName: String,
+        namespace: String? = "default",
+        deployment: ExtensionsV1beta1Deployment,
+        pretty: String? = null,
+        dryRun: String? = null
+    ): ExtensionsV1beta1Deployment {
+        try {
+            return extV1beta1Api.replaceNamespacedDeployment(deploymentName, namespace, deployment, pretty, dryRun)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun patchDeployment(
+        deploymentName: String,
+        namespace: String? = "default",
+        deployment: Any,
+        pretty: String? = null,
+        dryRun: String? = null
+    ): ExtensionsV1beta1Deployment {
+        try {
+            return extV1beta1Api.patchNamespacedDeployment(deploymentName, namespace, deployment, pretty, dryRun)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun deleteDeployment(
+        deploymentName: String,
+        namespace: String? = "default",
+        pretty: String? = null,
+        deleteOptions: V1DeleteOptions? = null,
+        dryRun: String? = null,
+        gracePeriodSeconds: Int? = null,
+        orphanDependents: Boolean? = null,
+        propagationPolicy: String? = null,
+        progressListener: ProgressResponseBody.ProgressListener? = null,
+        progressRequestListener: ProgressRequestBody.ProgressRequestListener? = null
+    ) {
+        val response = extV1beta1Api.deleteNamespacedDeploymentCall(deploymentName, namespace, pretty, deleteOptions, dryRun, gracePeriodSeconds, orphanDependents, propagationPolicy, progressListener, progressRequestListener).execute()
+
+        if (!response.isSuccessful) {
+            throw createKubernetesApiException(response.message())
+        }
+    }
+
+    fun getNamespace(
+        namespaceName: String,
+        pretty: String? = null,
+        exact: Boolean? = null,
+        export: Boolean? = null
+    ): V1Namespace {
+        try {
+            return coreV1Api.readNamespace(namespaceName, pretty, exact, export)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun getNamespaceList(
+        includeUninitialized: Boolean? = null,
+        pretty: String? = null,
+        _continue: String? = null,
+        fieldSelector: String? = null,
+        labelSelector: String? = null,
+        limit: Int? = null,
+        resourceVersion: String? = null,
+        timeoutSeconds: Int? = null,
+        watch: Boolean? = null
+    ): V1NamespaceList {
+        try {
+            return coreV1Api.listNamespace(includeUninitialized, pretty, _continue, fieldSelector, labelSelector, limit, resourceVersion, timeoutSeconds, watch)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun createNamespace(
+        namespace: V1Namespace,
+        includeUninitialized: Boolean? = null,
+        pretty: String? = null,
+        dryRun: String? = null
+    ): V1Namespace {
+        try {
+            return coreV1Api.createNamespace(namespace, includeUninitialized, pretty, dryRun)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun replaceNamespace(
+        namespaceName: String,
+        namespace: V1Namespace,
+        pretty: String? = null,
+        dryRun: String? = null
+    ): V1Namespace {
+        try {
+            return coreV1Api.replaceNamespace(namespaceName, namespace, pretty, dryRun)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun patchNamespace(
+        namespaceName: String,
+        namespace: Any,
+        pretty: String? = null,
+        dryRun: String? = null
+    ): V1Namespace {
+        try {
+            return coreV1Api.patchNamespace(namespaceName, namespace, pretty, dryRun)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun deleteNamespace(
+        namespaceName: String,
+        pretty: String? = null,
+        deleteOptions: V1DeleteOptions? = null,
+        dryRun: String? = null,
+        gracePeriodSeconds: Int? = null,
+        orphanDependents: Boolean? = null,
+        propagationPolicy: String? = null,
+        progressListener: ProgressResponseBody.ProgressListener? = null,
+        progressRequestListener: ProgressRequestBody.ProgressRequestListener? = null
+    ) {
+        val response = coreV1Api.deleteNamespaceCall(namespaceName, pretty, deleteOptions, dryRun, gracePeriodSeconds, orphanDependents, propagationPolicy, progressListener, progressRequestListener).execute()
+
+        if (!response.isSuccessful) {
+            throw createKubernetesApiException(response.message())
+        }
+    }
+
+    fun getNode(
+        nodeName: String,
+        pretty: String? = "default",
+        exact: Boolean? = null,
+        export: Boolean? = null
+    ): V1Node {
+        try {
+            return coreV1Api.readNode(nodeName, pretty, exact, export)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun getNodeList(
+        includeUninitialized: Boolean? = null,
+        pretty: String? = null,
+        _continue: String? = null,
+        fieldSelector: String? = null,
+        labelSelector: String? = null,
+        limit: Int? = null,
+        resourceVersion: String? = null,
+        timeoutSeconds: Int? = null,
+        watch: Boolean? = null
+    ): V1NodeList {
+        try {
+            return coreV1Api.listNode(includeUninitialized, pretty, _continue, fieldSelector, labelSelector, limit, resourceVersion, timeoutSeconds, watch)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun createNode(
+        node: V1Node,
+        includeUninitialized: Boolean? = null,
+        pretty: String? = null,
+        dryRun: String? = null
+    ): V1Node {
+        try {
+            return coreV1Api.createNode(node, includeUninitialized, pretty, dryRun)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun replaceNode(
+        nodeName: String,
+        node: V1Node,
+        pretty: String? = null,
+        dryRun: String? = null
+    ): V1Node {
+        try {
+            return coreV1Api.replaceNode(nodeName, node, pretty, dryRun)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun patchNode(
+        nodeName: String,
+        node: Any,
+        pretty: String? = null,
+        dryRun: String? = null
+    ): V1Node {
+        try {
+            return coreV1Api.patchNode(nodeName, node, pretty, dryRun)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun deleteNode(
+        nodeName: String,
+        pretty: String? = null,
+        deleteOptions: V1DeleteOptions? = null,
+        dryRun: String? = null,
+        gracePeriodSeconds: Int? = null,
+        orphanDependents: Boolean? = null,
+        propagationPolicy: String? = null,
+        progressListener: ProgressResponseBody.ProgressListener? = null,
+        progressRequestListener: ProgressRequestBody.ProgressRequestListener? = null
+    ) {
+        val response = coreV1Api.deleteNodeCall(nodeName, pretty, deleteOptions, dryRun, gracePeriodSeconds, orphanDependents, propagationPolicy, progressListener, progressRequestListener).execute()
+
+        if (!response.isSuccessful) {
+            throw createKubernetesApiException(response.message())
+        }
+    }
+
+    fun getPod(
+        podName: String,
+        namespace: String? = "default",
+        pretty: String? = null,
+        exact: Boolean? = null,
+        export: Boolean? = null
+    ): V1Pod {
+        try {
+            return coreV1Api.readNamespacedPod(podName, namespace, pretty, exact, export)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun getPodList(
+        namespace: String? = "default",
+        includeUninitialized: Boolean? = null,
+        pretty: String? = null,
+        _continue: String? = null,
+        fieldSelector: String? = null,
+        labelSelector: String? = null,
+        limit: Int? = null,
+        resourceVersion: String? = null,
+        timeoutSeconds: Int? = null,
+        watch: Boolean? = null
+    ): V1PodList {
+        try {
+            return coreV1Api.listNamespacedPod(namespace, includeUninitialized, pretty, _continue, fieldSelector, labelSelector, limit, resourceVersion, timeoutSeconds, watch)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun getPodListForAllNamespaces(
+        _continue: String? = null,
+        fieldSelector: String? = null,
+        includeUninitialized: Boolean? = null,
+        labelSelector: String? = null,
+        limit: Int? = null,
+        pretty: String? = null,
+        resourceVersion: String? = null,
+        timeoutSeconds: Int? = null,
+        watch: Boolean? = null
+    ): V1PodList {
+        try {
+            return coreV1Api.listPodForAllNamespaces(_continue, fieldSelector, includeUninitialized, labelSelector, limit, pretty, resourceVersion, timeoutSeconds, watch)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun createPod(
+        namespace: String? = "default",
+        pod: V1Pod,
+        includeUninitialized: Boolean? = null,
+        pretty: String? = null,
+        dryRun: String? = null
+    ): V1Pod {
+        try {
+            return coreV1Api.createNamespacedPod(namespace, pod, includeUninitialized, pretty, dryRun)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun replacePod(
+        podName: String,
+        namespace: String? = "default",
+        pod: V1Pod,
+        pretty: String? = null,
+        dryRun: String? = null
+    ): V1Pod {
+        try {
+            return coreV1Api.replaceNamespacedPod(podName, namespace, pod, pretty, dryRun)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun patchPod(
+        podName: String,
+        namespace: String? = "default",
+        pod: Any,
+        pretty: String? = null,
+        dryRun: String? = null
+    ): V1Pod {
+        try {
+            return coreV1Api.patchNamespacedPod(podName, namespace, pod, pretty, dryRun)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun deletePod(
+        podName: String,
+        namespace: String? = "default",
+        pretty: String? = null,
+        deleteOptions: V1DeleteOptions? = null,
+        dryRun: String? = null,
+        gracePeriodSeconds: Int? = null,
+        orphanDependents: Boolean? = null,
+        propagationPolicy: String? = null,
+        progressListener: ProgressResponseBody.ProgressListener? = null,
+        progressRequestListener: ProgressRequestBody.ProgressRequestListener? = null
+    ) {
+        val response = coreV1Api.deleteNamespacedPodCall(podName, namespace, pretty, deleteOptions, dryRun, gracePeriodSeconds, orphanDependents, propagationPolicy, progressListener, progressRequestListener).execute()
+
+        if (!response.isSuccessful) {
+            throw createKubernetesApiException(response.message())
+        }
+    }
+
+    fun getReplicaSet(
+        replicaSetName: String,
+        namespace: String? = "default",
+        pretty: String? = null,
+        exact: Boolean? = null,
+        export: Boolean? = null
+    ): V1ReplicaSet {
+        try {
+            return appsV1Api.readNamespacedReplicaSet(replicaSetName, namespace, pretty, exact, export)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun getReplicaSetList(
+        namespace: String? = "default",
+        includeUninitialized: Boolean? = null,
+        pretty: String? = null,
+        _continue: String? = null,
+        fieldSelector: String? = null,
+        labelSelector: String? = null,
+        limit: Int? = null,
+        resourceVersion: String? = null,
+        timeoutSeconds: Int? = null,
+        watch: Boolean? = null
+    ): V1ReplicaSetList {
+        try {
+            return appsV1Api.listNamespacedReplicaSet(namespace, includeUninitialized, pretty, _continue, fieldSelector, labelSelector, limit, resourceVersion, timeoutSeconds, watch)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun getReplicaSetListForAllNamespaces(
+        _continue: String? = null,
+        fieldSelector: String? = null,
+        includeUninitialized: Boolean? = null,
+        labelSelector: String? = null,
+        limit: Int? = null,
+        pretty: String? = null,
+        resourceVersion: String? = null,
+        timeoutSeconds: Int? = null,
+        watch: Boolean? = null
+    ): V1ReplicaSetList {
+        try {
+            return appsV1Api.listReplicaSetForAllNamespaces(_continue, fieldSelector, includeUninitialized, labelSelector, limit, pretty, resourceVersion, timeoutSeconds, watch)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun createReplicaSet(
+        namespace: String? = "default",
+        replicaSet: V1ReplicaSet,
+        includeUninitialized: Boolean? = null,
+        pretty: String? = null,
+        dryRun: String? = null
+    ): V1ReplicaSet {
+        try {
+            return appsV1Api.createNamespacedReplicaSet(namespace, replicaSet, includeUninitialized, pretty, dryRun)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun replaceReplicaSet(
+        replicaSetName: String,
+        namespace: String? = "default",
+        replicaSet: V1ReplicaSet,
+        pretty: String? = null,
+        dryRun: String? = null
+    ): V1ReplicaSet {
+        try {
+            return appsV1Api.replaceNamespacedReplicaSet(replicaSetName, namespace, replicaSet, pretty, dryRun)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun patchReplicaSet(
+        replicaSetName: String,
+        namespace: String? = "default",
+        replicaSet: Any,
+        pretty: String? = null,
+        dryRun: String? = null
+    ): V1ReplicaSet {
+        try {
+            return appsV1Api.patchNamespacedReplicaSet(replicaSetName, namespace, replicaSet, pretty, dryRun)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun deleteReplicaSet(
+        replicaSetName: String,
+        namespace: String? = "default",
+        pretty: String? = null,
+        deleteOptions: V1DeleteOptions? = null,
+        dryRun: String? = null,
+        gracePeriodSeconds: Int? = null,
+        orphanDependents: Boolean? = null,
+        propagationPolicy: String? = null,
+        progressListener: ProgressResponseBody.ProgressListener? = null,
+        progressRequestListener: ProgressRequestBody.ProgressRequestListener? = null
+    ) {
+        val response = appsV1Api.deleteNamespacedReplicaSetCall(replicaSetName, namespace, pretty, deleteOptions, dryRun, gracePeriodSeconds, orphanDependents, propagationPolicy, progressListener, progressRequestListener).execute()
+
+        if (!response.isSuccessful) {
+            throw createKubernetesApiException(response.message())
+        }
+    }
+
+    fun getSecret(
+        secretName: String,
+        namespace: String? = "default",
+        pretty: String? = null,
+        exact: Boolean? = null,
+        export: Boolean? = null
+    ): V1Secret {
+        try {
+            return coreV1Api.readNamespacedSecret(secretName, namespace, pretty, exact, export)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun getSecretList(
+        namespace: String? = "default",
+        includeUninitialized: Boolean? = null,
+        pretty: String? = null,
+        _continue: String? = null,
+        fieldSelector: String? = null,
+        labelSelector: String? = null,
+        limit: Int? = null,
+        resourceVersion: String? = null,
+        timeoutSeconds: Int? = null,
+        watch: Boolean? = null
+    ): V1SecretList {
+        try {
+            return coreV1Api.listNamespacedSecret(namespace, includeUninitialized, pretty, _continue, fieldSelector, labelSelector, limit, resourceVersion, timeoutSeconds, watch)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun getSecretListForAllNamespaces(
+        _continue: String? = null,
+        fieldSelector: String? = null,
+        includeUninitialized: Boolean? = null,
+        labelSelector: String? = null,
+        limit: Int? = null,
+        pretty: String? = null,
+        resourceVersion: String? = null,
+        timeoutSeconds: Int? = null,
+        watch: Boolean? = null
+    ): V1SecretList {
+        try {
+            return coreV1Api.listSecretForAllNamespaces(_continue, fieldSelector, includeUninitialized, labelSelector, limit, pretty, resourceVersion, timeoutSeconds, watch)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun createSecret(
+        namespace: String? = "default",
+        secret: V1Secret,
+        includeUninitialized: Boolean? = null,
+        pretty: String? = null,
+        dryRun: String? = null
+    ): V1Secret {
+        try {
+            return coreV1Api.createNamespacedSecret(namespace, secret, includeUninitialized, pretty, dryRun)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun replaceSecret(
+        secretName: String,
+        namespace: String? = "default",
+        secret: V1Secret,
+        pretty: String? = null,
+        dryRun: String? = null
+    ): V1Secret {
+        try {
+            return coreV1Api.replaceNamespacedSecret(secretName, namespace, secret, pretty, dryRun)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun patchSecret(
+        secretName: String,
+        namespace: String? = "default",
+        secret: Any,
+        pretty: String? = null,
+        dryRun: String? = null
+    ): V1Secret {
+        try {
+            return coreV1Api.patchNamespacedSecret(secretName, namespace, secret, pretty, dryRun)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun deleteSecret(
+        secretName: String,
+        namespace: String? = "default",
+        pretty: String? = null,
+        deleteOptions: V1DeleteOptions? = null,
+        dryRun: String? = null,
+        gracePeriodSeconds: Int? = null,
+        orphanDependents: Boolean? = null,
+        propagationPolicy: String? = null,
+        progressListener: ProgressResponseBody.ProgressListener? = null,
+        progressRequestListener: ProgressRequestBody.ProgressRequestListener? = null
+    ) {
+        val response = coreV1Api.deleteNamespacedSecretCall(secretName, namespace, pretty, deleteOptions, dryRun, gracePeriodSeconds, orphanDependents, propagationPolicy, progressListener, progressRequestListener).execute()
+
+        if (!response.isSuccessful) {
+            throw createKubernetesApiException(response.message())
+        }
+    }
+
+    fun getService(
+        serviceName: String,
+        namespace: String? = "default",
+        pretty: String? = null,
+        exact: Boolean? = null,
+        export: Boolean? = null
+    ): V1Service {
+        try {
+            return coreV1Api.readNamespacedService(serviceName, namespace, pretty, exact, export)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun getServiceList(
+        namespace: String? = "default",
+        includeUninitialized: Boolean? = null,
+        pretty: String? = null,
+        _continue: String? = null,
+        fieldSelector: String? = null,
+        labelSelector: String? = null,
+        limit: Int? = null,
+        resourceVersion: String? = null,
+        timeoutSeconds: Int? = null,
+        watch: Boolean? = null
+    ): V1ServiceList {
+        try {
+            return coreV1Api.listNamespacedService(namespace, includeUninitialized, pretty, _continue, fieldSelector, labelSelector, limit, resourceVersion, timeoutSeconds, watch)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun getServiceListForAllNamespaces(
+        _continue: String? = null,
+        fieldSelector: String? = null,
+        includeUninitialized: Boolean? = null,
+        labelSelector: String? = null,
+        limit: Int? = null,
+        pretty: String? = null,
+        resourceVersion: String? = null,
+        timeoutSeconds: Int? = null,
+        watch: Boolean? = null
+    ): V1ServiceList {
+        try {
+            return coreV1Api.listServiceForAllNamespaces(_continue, fieldSelector, includeUninitialized, labelSelector, limit, pretty, resourceVersion, timeoutSeconds, watch)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun createService(
+        namespace: String? = "default",
+        service: V1Service,
+        includeUninitialized: Boolean? = null,
+        pretty: String? = null,
+        dryRun: String? = null
+    ): V1Service {
+        try {
+            return coreV1Api.createNamespacedService(namespace, service, includeUninitialized, pretty, dryRun)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun replaceService(
+        serviceName: String,
+        namespace: String? = "default",
+        service: V1Service,
+        pretty: String? = null,
+        dryRun: String? = null
+    ): V1Service {
+        try {
+            return coreV1Api.replaceNamespacedService(serviceName, namespace, service, pretty, dryRun)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun patchService(
+        serviceName: String,
+        namespace: String? = "default",
+        service: Any,
+        pretty: String? = null,
+        dryRun: String? = null
+    ): V1Service {
+        try {
+            return coreV1Api.patchNamespacedService(serviceName, namespace, service, pretty, dryRun)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun deleteService(
+        serviceName: String,
+        namespace: String? = "default",
+        pretty: String? = null,
+        deleteOptions: V1DeleteOptions? = null,
+        dryRun: String? = null,
+        gracePeriodSeconds: Int? = null,
+        orphanDependents: Boolean? = null,
+        propagationPolicy: String? = null,
+        progressListener: ProgressResponseBody.ProgressListener? = null,
+        progressRequestListener: ProgressRequestBody.ProgressRequestListener? = null
+    ) {
+        val response = coreV1Api.deleteNamespacedServiceCall(serviceName, namespace, pretty, deleteOptions, dryRun, gracePeriodSeconds, orphanDependents, propagationPolicy, progressListener, progressRequestListener).execute()
+
+        if (!response.isSuccessful) {
+            throw createKubernetesApiException(response.message())
+        }
+    }
+
+    fun getStatefulSet(
+        statefulSetName: String,
+        namespace: String? = "default",
+        pretty: String? = null,
+        exact: Boolean? = null,
+        export: Boolean? = null
+    ): V1StatefulSet {
+        try {
+            return appsV1Api.readNamespacedStatefulSet(statefulSetName, namespace, pretty, exact, export)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun getStatefulSetList(
+        namespace: String? = "default",
+        includeUninitialized: Boolean? = null,
+        pretty: String? = null,
+        _continue: String? = null,
+        fieldSelector: String? = null,
+        labelSelector: String? = null,
+        limit: Int? = null,
+        resourceVersion: String? = null,
+        timeoutSeconds: Int? = null,
+        watch: Boolean? = null
+    ): V1StatefulSetList {
+        try {
+            return appsV1Api.listNamespacedStatefulSet(namespace, includeUninitialized, pretty, _continue, fieldSelector, labelSelector, limit, resourceVersion, timeoutSeconds, watch)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun getStatefulSetListForAllNamespaces(
+        _continue: String? = null,
+        fieldSelector: String? = null,
+        includeUninitialized: Boolean? = null,
+        labelSelector: String? = null,
+        limit: Int? = null,
+        pretty: String? = null,
+        resourceVersion: String? = null,
+        timeoutSeconds: Int? = null,
+        watch: Boolean? = null
+    ): V1StatefulSetList {
+        try {
+            return appsV1Api.listStatefulSetForAllNamespaces(_continue, fieldSelector, includeUninitialized, labelSelector, limit, pretty, resourceVersion, timeoutSeconds, watch)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun createStatefulSet(
+        namespace: String? = "default",
+        statefulSet: V1StatefulSet,
+        includeUninitialized: Boolean? = null,
+        pretty: String? = null,
+        dryRun: String? = null
+    ): V1StatefulSet {
+        try {
+            return appsV1Api.createNamespacedStatefulSet(namespace, statefulSet, includeUninitialized, pretty, dryRun)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun replaceStatefulSet(
+        statefulSetName: String,
+        namespace: String? = "default",
+        statefulSet: V1StatefulSet,
+        pretty: String? = null,
+        dryRun: String? = null
+    ): V1StatefulSet {
+        try {
+            return appsV1Api.replaceNamespacedStatefulSet(statefulSetName, namespace, statefulSet, pretty, dryRun)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun patchStatefulSet(
+        statefulSetName: String,
+        namespace: String? = "default",
+        statefulSet: Any,
+        pretty: String? = null,
+        dryRun: String? = null
+    ): V1StatefulSet {
+        try {
+            return appsV1Api.patchNamespacedStatefulSet(statefulSetName, namespace, statefulSet, pretty, dryRun)
+        } catch (e: Exception) {
+            throw createKubernetesApiException(e.message, e.cause)
+        }
+    }
+
+    fun deleteStatefulSet(
+        statefulSetName: String,
+        namespace: String? = "default",
+        pretty: String? = null,
+        deleteOptions: V1DeleteOptions? = null,
+        dryRun: String? = null,
+        gracePeriodSeconds: Int? = null,
+        orphanDependents: Boolean? = null,
+        propagationPolicy: String? = null,
+        progressListener: ProgressResponseBody.ProgressListener? = null,
+        progressRequestListener: ProgressRequestBody.ProgressRequestListener? = null
+    ) {
+        val response = appsV1Api.deleteNamespacedStatefulSetCall(statefulSetName, namespace, pretty, deleteOptions, dryRun, gracePeriodSeconds, orphanDependents, propagationPolicy, progressListener, progressRequestListener).execute()
+
+        if (!response.isSuccessful) {
+            throw createKubernetesApiException(response.message())
+        }
     }
 }

--- a/kubernetes/src/main/kotlin/org/jaram/jubaky/kubernetes/ToDomainModel.kt
+++ b/kubernetes/src/main/kotlin/org/jaram/jubaky/kubernetes/ToDomainModel.kt
@@ -1,0 +1,640 @@
+package org.jaram.jubaky.kubernetes
+
+import io.kubernetes.client.custom.IntOrString
+import io.kubernetes.client.custom.Quantity
+import io.kubernetes.client.models.*
+import org.jaram.jubaky.domain.kubernetes.*
+
+fun V1Container.toDomainModel(): Container = Container(
+    args = this.args,
+    command = this.command,
+    image = this.image,
+    name  = this.name,
+    containerPorts = this.ports?.map { port -> port.toDomainModel() },
+    resources = this.resources?.toDomainModel(),
+    terminationMessagePath = this.terminationMessagePath,
+    terminationMessagePolicy = this.terminationMessagePolicy,
+    tty = this.isTty,
+    volumeDevices = this.volumeDevices?.map { volumeDevice -> volumeDevice.toDomainModel() },
+    volumeMounts = this.volumeMounts?.map { volumeMount -> volumeMount.toDomainModel() },
+    workingDir = this.workingDir
+)
+
+fun V1ContainerImage.toDomainModel(): Container.ContainerImage = Container.ContainerImage(
+    names = this.names,
+    sizeBytes = this.sizeBytes
+)
+
+fun V1ContainerPort.toDomainModel(): Container.ContainerPort = Container.ContainerPort(
+    containerPort = this.containerPort,
+    hostIP = this.hostIP,
+    hostPort = this.hostPort,
+    name = this.name,
+    protocol = this.protocol
+)
+
+fun V1ContainerStatus.toDomainModel(): Container.ContainerStatus = Container.ContainerStatus(
+    containerID = this.containerID,
+    image = this.image,
+    imageID = this.imageID,
+    lastState = this.lastState?.toDomainModel(),
+    name = this.name,
+    ready = this.isReady,
+    restartCount = this.restartCount,
+    state = this.state?.toDomainModel()
+)
+
+fun V1ContainerState.toDomainModel(): Container.ContainerState = Container.ContainerState(
+    running = this.running?.toDoaminModel(),
+    terminated = this.terminated?.toDomainModel(),
+    waiting = this.waiting?.toDoaminModel()
+)
+
+fun V1ContainerStateRunning.toDoaminModel(): Container.ContainerState.ContainerStateRunning = Container.ContainerState.ContainerStateRunning(
+    startedAt = this.startedAt
+)
+
+fun V1ContainerStateTerminated.toDomainModel(): Container.ContainerState.ContainerStateTerminated = Container.ContainerState.ContainerStateTerminated(
+    containerID = this.containerID,
+    exitCode = this.exitCode,
+    finishedAt = this.finishedAt,
+    message = this.message,
+    reason = this.reason,
+    signal = this.signal,
+    startedAt = this.startedAt
+)
+
+fun V1ContainerStateWaiting.toDoaminModel(): Container.ContainerState.ContainerStateWaiting = Container.ContainerState.ContainerStateWaiting(
+    message = this.message,
+    reason = this.reason
+)
+
+fun V1beta1DaemonSet.toDomainModel(): DaemonSet = DaemonSet(
+    apiVersion = apiVersion,
+    kind = kind,
+    metadata = metadata?.toDomainModel(),
+    spec = DaemonSet.DaemonSetSpec(
+        revisionHistoryLimit = spec.revisionHistoryLimit,
+        selector = spec.selector?.toDomainModel(),
+        template = spec.template?.toDomainModel(),
+        templateGeneration = spec.templateGeneration,
+        updateStrategy = DaemonSet.DaemonSetUpdateStrategy(
+            rollingUpdate = DaemonSet.DaemonSetRollingUpdate(
+                maxUnavailable = spec.updateStrategy?.rollingUpdate?.maxUnavailable?.getValue()
+            ),
+            type = spec.updateStrategy?.type
+        )
+    ),
+    status = DaemonSet.DaemonSetStatus(
+        collisionCount = status.collisionCount,
+        conditions = status.conditions?.map { condition -> condition.toDomainModel() },
+        currentNumberScheduled = status.currentNumberScheduled,
+        desiredNumberScheduled = status.desiredNumberScheduled,
+        numberAvailable = status.numberAvailable,
+        numberMisscheduled = status.numberMisscheduled,
+        numberReady = status.numberReady,
+        numberUnavailable = status.numberUnavailable,
+        observedGeneration = status.observedGeneration,
+        updatedNumberScheduled = status.updatedNumberScheduled
+    )
+)
+
+fun V1beta1DaemonSetCondition.toDomainModel(): DaemonSet.DaemonSetCondition = DaemonSet.DaemonSetCondition(
+    message = this.message,
+    reason = this.reason,
+    status = this.status,
+    type = this.type
+)
+
+fun ExtensionsV1beta1Deployment.toDomainModel(): Deployment = Deployment(
+    apiVersion = apiVersion,
+    kind= kind,
+    metadata = metadata?.toDomainModel(),
+    spec = Deployment.DeploymentSpec(
+        progressDeadlineSeconds = spec.progressDeadlineSeconds,
+        replicas = spec.replicas,
+        revisionHistoryLimit = spec.revisionHistoryLimit,
+        selector = spec.selector.toDomainModel(),
+        strategy = Deployment.DeploymentStrategy(
+            rollingUpdate = Deployment.DeploymentRollingUpdate(
+                maxSurge = spec.strategy?.rollingUpdate?.maxSurge,
+                maxUnavailable = spec.strategy?.rollingUpdate?.maxUnavailable
+            ),
+            type = spec.strategy?.type
+        ),
+        template = spec.template?.toDomainModel()
+    ),
+    status = Deployment.DeploymentStatus(
+        availableReplicas = status.availableReplicas,
+        collisionCount = status.collisionCount,
+        conditions = status.conditions?.map { condition -> condition.toDomainModel() },
+        observedGeneration = status.observedGeneration,
+        readyReplicas = status.readyReplicas,
+        replicas = status.replicas,
+        unavailableReplicas = status.unavailableReplicas,
+        updatedReplicas = status.updatedReplicas
+    )
+)
+
+fun ExtensionsV1beta1DeploymentCondition.toDomainModel(): Deployment.DeploymentCondition = Deployment.DeploymentCondition(
+    lastTransitionTime = this.lastTransitionTime,
+    lastUpdateTime = this.lastUpdateTime,
+    message = this.message,
+    reason = this.reason,
+    status = this.status,
+    type = this.type
+)
+
+fun V1HostAlias.toDomainModel(): Pod.HostAlias = Pod.HostAlias(
+    hostnames = this.hostnames,
+    ip = this.ip
+)
+
+fun V1HostPathVolumeSource.toDomainModel(): Volume.HostPathVolumeSource = Volume.HostPathVolumeSource(
+    path = this.path,
+    type = this.type
+)
+
+fun V1Initializer.toDomainModel(): Metadata.Initializers.Initializer = Metadata.Initializers.Initializer(
+    name = this.name
+)
+
+fun V1Initializers.toDomainModel(): Metadata.Initializers = Metadata.Initializers(
+    pending = this.pending?.map { initializer -> initializer.toDomainModel() },
+    result = this.result?.toDomainModel()
+)
+
+fun V1LabelSelector.toDomainModel(): Selector = Selector(
+    matchExpressions = this.matchExpressions?.map { matchExpression -> matchExpression.toDomainModel() },
+    matchLabels = this.matchLabels
+)
+
+fun V1LabelSelectorRequirement.toDomainModel(): Selector.SelectorRequirements = Selector.SelectorRequirements(
+    key = this.key,
+    operator = this.operator,
+    values = this.values
+)
+
+fun V1ListMeta.toDomainModel(): Status.ListMeta {
+    return Status.ListMeta(
+        _continue = this.`continue`,
+        resourceVersion = this.resourceVersion,
+        selfLink = this.selfLink
+    )
+}
+
+fun V1LoadBalancerIngress.toDomainModel(): Service.LoadBalancerIngress = Service.LoadBalancerIngress(
+    hostname = this.hostname,
+    ip = this.ip
+)
+
+fun V1Namespace.toDomainModel(): Namespace = Namespace(
+    apiVersion = apiVersion,
+    kind = kind,
+    metadata = metadata?.toDomainModel(),
+    spec = Namespace.NamespaceSpec(
+        finalizers = spec.finalizers
+    ),
+    status = Namespace.NamespaceStatus(
+        phase = status.phase
+    )
+)
+
+fun V1Node.toDomainModel(): Node {
+    val allocatableMap = mutableMapOf<String, Resource.Quantity>()
+    val capacityMap = mutableMapOf<String, Resource.Quantity>()
+
+    for (allocatable in status.allocatable?: mapOf()) {
+        allocatableMap[allocatable.key] = allocatable.value.toDomainModel()
+    }
+
+    for (capacity in status.capacity?: mapOf()) {
+        capacityMap[capacity.key] = capacity.value.toDomainModel()
+    }
+
+    return Node(
+        apiVersion = apiVersion,
+        kind = kind,
+        metadata = metadata?.toDomainModel(),
+        spec = Node.NodeSpec(
+            configSource = Node.NodeConfigSource(
+                configMap = Node.ConfigMapNodeConfigSource(
+                    kubeletConfigKey = spec.configSource?.configMap?.kubeletConfigKey,
+                    name = spec.configSource?.configMap?.name,
+                    namespace = spec.configSource?.configMap?.namespace,
+                    resourceVersion = spec.configSource?.configMap?.resourceVersion,
+                    uid = spec.configSource?.configMap?.uid
+                )
+            ),
+            externalID = spec.externalID,
+            podCIDR = spec.podCIDR,
+            providerID = spec.providerID,
+            taints = spec.taints?.map { taint -> taint.toDomainModel() },
+            unschedulable = spec.isUnschedulable
+        ),
+        status = Node.NodeStatus(
+            addresses = status.addresses?.map { address -> address.toDomainModel() },
+            allocatable = allocatableMap,
+            capacity = capacityMap,
+            conditions = status.conditions?.map { condition -> condition.toDomainModel() },
+            daemonEndpoints = Node.NodeDaemonEndpoints(
+                kubeletEndpoint = Node.DaemonEndpoint(
+                    Port = status.daemonEndpoints?.kubeletEndpoint?.port
+                )
+            ),
+            images = status.images?.map { image -> image.toDomainModel() },
+            nodeInfo = Node.NodeSystemInfo(
+                architecture = status.nodeInfo?.architecture,
+                bootID = status.nodeInfo?.bootID,
+                containerRuntimeVersion = status.nodeInfo?.containerRuntimeVersion,
+                kernelVersion = status.nodeInfo?.kernelVersion,
+                kubeProxyVersion = status.nodeInfo?.kubeProxyVersion,
+                kubeletVersion = status.nodeInfo?.kubeletVersion,
+                machineID = status.nodeInfo?.machineID,
+                operatingSystem = status.nodeInfo?.operatingSystem,
+                osImage = status.nodeInfo?.osImage,
+                systemUUID = status.nodeInfo?.systemUUID
+            ),
+            phase = status.phase
+        )
+    )
+}
+
+fun V1NodeAddress.toDomainModel(): Node.NodeAddress = Node.NodeAddress(
+    address = this.address,
+    type = this.type
+)
+
+fun V1NodeCondition.toDomainModel(): Node.NodeCondition = Node.NodeCondition(
+    lastHeartbeatTime = this.lastHeartbeatTime,
+    lastTransitionTime = this.lastTransitionTime,
+    message = this.message,
+    reason = this.reason,
+    status = this.status,
+    type = this.type
+)
+
+fun V1ObjectMeta.toDomainModel(): Metadata = Metadata(
+    annotations = this.annotations?: mapOf(),
+    clusterName = this.clusterName,
+    creationTimestamp = this.creationTimestamp,
+    deletionGracePeriodSeconds = this.deletionGracePeriodSeconds,
+    deletionTimestamp = this.deletionTimestamp,
+    finalizers = this.finalizers,
+    generateName = this.generateName,
+    generation = this.generation,
+    initializers = this.initializers?.toDomainModel(),
+    labels = this.labels?: mapOf(),
+    name = this.name,
+    namespace = this.namespace,
+    ownerReference = this.ownerReferences?.map { ownerReference -> ownerReference.toDomainModel() },
+    resourceVersion = this.resourceVersion,
+    uid = this.uid
+)
+
+fun V1OwnerReference.toDomainModel(): Metadata.OwnerReference = Metadata.OwnerReference(
+    apiVersion = this.apiVersion,
+    blockOwnerDeletion = this.isBlockOwnerDeletion,
+    controller = this.isController,
+    kind = this.kind,
+    name = this.name,
+    uid = this.uid
+)
+
+fun V1PersistentVolumeClaim.toDomainModel(): PersistentVolumeClaim {
+    val resourceLimitsMap = mutableMapOf<String, Resource.Quantity>()
+    val resourceRequestsMap = mutableMapOf<String, Resource.Quantity>()
+    val capacityMap = mutableMapOf<String, Resource.Quantity>()
+
+    for (resourceLimit in this.spec.resources?.limits?: mapOf()) {
+        resourceLimitsMap[resourceLimit.key] = resourceLimit.value.toDomainModel()
+    }
+
+    for (resourceRequest in this.spec.resources?.requests?: mapOf()) {
+        resourceRequestsMap[resourceRequest.key] = resourceRequest.value.toDomainModel()
+    }
+
+    for (capacity in this.status.capacity?: mapOf()) {
+        capacityMap[capacity.key] = capacity.value.toDomainModel()
+    }
+
+    return PersistentVolumeClaim(
+        apiVersion = this.apiVersion,
+        kind = this.kind,
+        metadata = this.metadata?.toDomainModel(),
+        spec = PersistentVolumeClaim.PersistentVolumeClaimSpec(
+            accessModes = this.spec.accessModes,
+            dataSource = PersistentVolumeClaim.TypedLocalObjectReference(
+                apiGroup = this.spec.dataSource?.apiGroup,
+                kind = this.spec.dataSource?.kind,
+                name = this.spec.dataSource?.name
+            ),
+            resources = Resource(
+                limits = resourceLimitsMap,
+                requests = resourceRequestsMap
+            ),
+            selector = this.spec.selector.toDomainModel(),
+            storageClassName = this.spec.storageClassName,
+            volumeMode = this.spec.volumeMode,
+            volumeName = this.spec.volumeName
+        ),
+        status = PersistentVolumeClaim.PersistentVolumeClaimStatus(
+            accessModes = this.status.accessModes,
+            capacity = capacityMap,
+            conditions = this.status.conditions?.map { condition -> condition.toDoaminModel() },
+            phase = this.status.phase
+        )
+    )
+}
+
+fun V1PersistentVolumeClaimCondition.toDoaminModel(): PersistentVolumeClaim.PersistentVolumeClaimCondition = PersistentVolumeClaim.PersistentVolumeClaimCondition(
+    lastProbeTime = this.lastProbeTime,
+    lastTransitionTime = this.lastTransitionTime,
+    message = this.message,
+    reason = this.reason,
+    status = this.status,
+    type = this.type
+)
+
+fun V1Pod.toDomainModel(): Pod = Pod(
+    apiVersion = apiVersion,
+    kind = kind,
+    metadata = metadata?.toDomainModel(),
+    spec = spec?.toDomainModel(),
+    status = Pod.PodStatus(
+        conditions = status.conditions?.map { condition -> condition.toDomainModel() },
+        containerStatuses = status.containerStatuses?.map { containerStatus -> containerStatus.toDomainModel() },
+        hostIP = status.hostIP,
+        initContainerStatuses = status.initContainerStatuses?.map { initContainerStatus -> initContainerStatus.toDomainModel() },
+        message = status.message,
+        nominatedNodeName = status.nominatedNodeName,
+        phase = status.phase,
+        podIP = status.podIP,
+        qosClass = status.qosClass,
+        reason = status.reason,
+        startTime = status.startTime
+    )
+)
+
+fun V1PodCondition.toDomainModel(): Pod.PodCondition = Pod.PodCondition(
+    lastProbeTime = this.lastProbeTime,
+    lastTransitionTime = this.lastTransitionTime,
+    message = this.message,
+    reason = this.reason,
+    status = this.status,
+    type = this.type
+)
+
+fun V1PodDNSConfig.toDomainModel(): Pod.PodDNSConfig = Pod.PodDNSConfig(
+    nameservers = this.nameservers,
+    options = this.options?.map { option -> option.toDomainModel() },
+    searches = this.searches
+)
+
+fun V1PodDNSConfigOption.toDomainModel(): Pod.PodDNSConfigOption = Pod.PodDNSConfigOption(
+    name = this.name,
+    value = this.value
+)
+
+fun V1PodSecurityContext.toDomainModel(): Pod.PodSecurityContext = Pod.PodSecurityContext(
+    fsGroup = this.fsGroup,
+    runAsGroup = this.runAsGroup,
+    runAsNonRoot = this.isRunAsNonRoot,
+    runAsUser = this.runAsUser
+)
+
+fun V1PodSpec.toDomainModel(): Pod.PodSpec = Pod.PodSpec(
+    containers = this.containers?.map { container -> container.toDomainModel() },
+    dnsConfig = this.dnsConfig?.toDomainModel(),
+    dnsPolicy = this.dnsPolicy,
+    enableServiceLinks = this.isEnableServiceLinks,
+    hostAliases = this.hostAliases?.map { hostAlias -> hostAlias.toDomainModel() },
+    hostIPC = this.isHostIPC,
+    hostNetwork = this.isHostNetwork,
+    hostPID = this.isHostPID,
+    hostname = this.hostname,
+    initContainers = this.initContainers?.map { container -> container.toDomainModel()},
+    nodeName = this.nodeName,
+    nodeSelector = this.nodeSelector,
+    priority = this.priority,
+    priorityClassName = this.priorityClassName,
+    restartPolicy = this.restartPolicy,
+    schedulerName = this.schedulerName,
+    securityContext = this.securityContext?.toDomainModel(),
+    serviceAccount = this.serviceAccount,
+    serviceAccountName = this.serviceAccountName,
+    shareProcessNamespace = this.isShareProcessNamespace,
+    subdomain = this.subdomain,
+    terminationGracePeriodSeconds = this.terminationGracePeriodSeconds,
+    tolerations = this.tolerations?.map { toleration -> toleration.toDomainModel() },
+    volumes = this.volumes?.map { volume -> volume.toDomainModel() }
+)
+
+fun V1PodTemplateSpec.toDomainModel(): PodTemplate.PodTemplateSpec = PodTemplate.PodTemplateSpec(
+    metadata = this.metadata?.toDomainModel(),
+    spec = this.spec?.toDomainModel()
+)
+
+fun Quantity.toDomainModel(): Resource.Quantity = Resource.Quantity(
+    number = this.number,
+    format = this.format.base
+)
+
+fun V1ReplicaSet.toDomainModel(): ReplicaSet = ReplicaSet(
+    apiVersion = apiVersion,
+    kind = kind,
+    metadata = metadata?.toDomainModel(),
+    spec = ReplicaSet.ReplicaSetSpec(
+        minReadySeconds = spec.minReadySeconds,
+        replicas = spec.replicas,
+        selector = spec.selector?.toDomainModel(),
+        template = spec.template?.toDomainModel()
+    ),
+    status = ReplicaSet.ReplicaSetStatus(
+        availableReplicas = status.availableReplicas,
+        conditions = status.conditions?.map { condition -> condition.toDomainModel() },
+        fullyLabeledReplicas = status.fullyLabeledReplicas,
+        observedGeneration = status.observedGeneration,
+        readyReplicas = status.readyReplicas,
+        replicas = status.replicas
+    )
+)
+
+fun V1ReplicaSetCondition.toDomainModel(): ReplicaSet.ReplicaSetCondition = ReplicaSet.ReplicaSetCondition(
+    lastTransitionTime = this.lastTransitionTime,
+    message = this.message,
+    reason = this.reason,
+    status = this.status,
+    type = this.type
+)
+
+fun V1ResourceRequirements.toDomainModel(): Resource {
+    val resourceLimitsMap = mutableMapOf<String, Resource.Quantity>()
+    val resourceRequestsMap = mutableMapOf<String, Resource.Quantity>()
+
+    for (resourceLimit in this.limits ?: mapOf()) {
+        resourceLimitsMap[resourceLimit.key] = resourceLimit.value.toDomainModel()
+    }
+
+    for (resourceRequest in this.requests ?: mapOf()) {
+        resourceRequestsMap[resourceRequest.key] = resourceRequest.value.toDomainModel()
+    }
+
+    return Resource(
+        limits = resourceLimitsMap,
+        requests = resourceRequestsMap
+    )
+}
+
+fun V1Secret.toDomainModel(): Secret = Secret(
+    apiVersion = apiVersion,
+    data = data,
+    kind = kind,
+    metadata = metadata?.toDomainModel(),
+    stringData = stringData,
+    type = type
+)
+
+fun V1Service.toDomainModel(): Service = Service(
+    apiVersion = apiVersion,
+    kind = kind,
+    metadata = metadata?.toDomainModel(),
+    spec = Service.ServiceSpec(
+        clusterIP = spec.clusterIP,
+        externalIPs = spec.externalIPs,
+        externalName = spec.externalName,
+        externalTrafficPolicy = spec.externalTrafficPolicy,
+        healthCheckNodePort = spec.healthCheckNodePort,
+        loadBalancerIP = spec.loadBalancerIP,
+        loadBalancerSourceRanges = spec.loadBalancerSourceRanges,
+        ports = spec.ports?.map { spec -> spec.toDomainModel() },
+        publishNotReadyAddresses = spec.isPublishNotReadyAddresses,
+        selector = spec.selector,
+        sessionAffinity = spec.sessionAffinity,
+        sessionAffinityConfig = Service.SessionAffinityConfig(
+            clientIP = Service.ClientIPConfig(
+                timeoutSeconds = spec.sessionAffinityConfig?.clientIP?.timeoutSeconds
+            )
+        ),
+        type = spec.type
+    ),
+    status = Service.ServiceStatus(
+        loadBalancer = Service.LoadBalancerStatus(
+            ingress = status.loadBalancer?.ingress?.map { ingress -> ingress.toDomainModel() }
+        )
+    )
+)
+
+fun V1ServicePort.toDomainModel(): Service.ServicePort = Service.ServicePort(
+    name = this.name,
+    nodePort = this.nodePort,
+    port = this.port,
+    protocol = this.protocol,
+    targetPort = this.targetPort?.getValue()
+)
+
+fun V1StatefulSet.toDomainModel(): StatefulSet = StatefulSet(
+    apiVersion = apiVersion,
+    kind = kind,
+    metadata = metadata?.toDomainModel(),
+    spec = StatefulSet.StatefulSetSpec(
+        podManagementPolicy = spec.podManagementPolicy,
+        replicas = spec.replicas,
+        revisionHistoryLimit = spec.revisionHistoryLimit,
+        selector = spec.selector?.toDomainModel(),
+        serviceName = spec.serviceName,
+        template = spec.template?.toDomainModel(),
+        updateStrategy = StatefulSet.StatefulSetUpdateStrategy(
+            rollingUpdate = StatefulSet.RollingUpdateStatefulSetStrategy(
+                partition = spec.updateStrategy?.rollingUpdate?.partition
+            ),
+            type = spec?.updateStrategy?.type
+        ),
+        volumeClaimTemplates = spec.volumeClaimTemplates?.map { volumeClaimTemplate -> volumeClaimTemplate.toDomainModel() }
+    ),
+    status = StatefulSet.StatefulSetStatus(
+        collisionCount = status.collisionCount,
+        conditions = status.conditions?.map { condition -> condition.toDomainModel() },
+        currentReplicas = status.currentReplicas,
+        currentRevision = status.currentRevision,
+        observedGeneration = status.observedGeneration,
+        readyReplicas = status.readyReplicas,
+        replicas = status.replicas,
+        updateRevision = status.updateRevision,
+        updatedReplicas = status.updatedReplicas
+    )
+)
+
+fun V1StatefulSetCondition.toDomainModel(): StatefulSet.StatefulSetCondition = StatefulSet.StatefulSetCondition(
+    lastTransitionTime = this.lastTransitionTime,
+    message = this.message,
+    reason = this.reason,
+    status = this.status,
+    type = this.type
+)
+
+fun V1Status.toDomainModel(): Status = Status(
+    apiVersion = this.apiVersion,
+    code = this.code,
+    details = this.details?.toDomainModel(),
+    kind = this.kind,
+    message = this.message,
+    metadata = this.metadata?.toDomainModel(),
+    reason = this.reason,
+    status = this.status
+)
+
+fun V1StatusCause.toDomainModel(): Status.StatusCause = Status.StatusCause(
+    field = this.field,
+    message = this.message,
+    reason = this.reason
+)
+
+fun V1StatusDetails.toDomainModel(): Status.StatusDetails = Status.StatusDetails(
+    causes = this.causes?.map { cause -> cause.toDomainModel() },
+    group = this.group,
+    kind = this.kind,
+    name = this.name,
+    retryAfterSeconds = this.retryAfterSeconds,
+    uid = this.uid
+)
+
+fun V1Taint.toDomainModel(): Taint = Taint(
+    effect = this.effect,
+    key = this.key,
+    timeAdded = this.timeAdded,
+    value = this.value
+)
+
+fun V1Toleration.toDomainModel(): Pod.Toleration = Pod.Toleration(
+    effect = this.effect,
+    key = this.key,
+    operator = this.operator,
+    tolerationSeconds = this.tolerationSeconds,
+    value = this.value
+)
+
+fun V1Volume.toDomainModel(): Volume = Volume(
+    name = this.name,
+    hostPath = this.hostPath?.toDomainModel()
+)
+
+fun V1VolumeDevice.toDomainModel(): Volume.VolumeDevice = Volume.VolumeDevice(
+    devicePath = this.devicePath,
+    name = this.name
+)
+
+fun V1VolumeMount.toDomainModel(): Volume.VolumeMount = Volume.VolumeMount(
+    mountPath = this.mountPath,
+    mountPropagation = this.mountPropagation,
+    name = this.name,
+    readOnly = this.isReadOnly,
+    subPath = this.subPath
+)
+
+private fun IntOrString.getValue(): Any {
+    return if (this.isInteger)
+        this.intValue
+    else
+        this.strValue
+}

--- a/kubernetes/src/main/kotlin/org/jaram/jubaky/kubernetes/repository/KubernetesRepositoryImpl.kt
+++ b/kubernetes/src/main/kotlin/org/jaram/jubaky/kubernetes/repository/KubernetesRepositoryImpl.kt
@@ -1,36 +1,215 @@
 package org.jaram.jubaky.kubernetes.repository
 
-import io.kubernetes.client.models.V1Namespace
-import io.kubernetes.client.models.V1Pod
+import io.kubernetes.client.models.*
+import io.kubernetes.client.util.Yaml
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import org.jaram.jubaky.domain.NameSpace
-import org.jaram.jubaky.domain.Pod
+import org.jaram.jubaky.domain.kubernetes.*
 import org.jaram.jubaky.kubernetes.KubernetesApi
+import org.jaram.jubaky.kubernetes.toDomainModel
 import org.jaram.jubaky.repository.KubernetesRepository
 
 class KubernetesRepositoryImpl(
     private val api: KubernetesApi
 ) : KubernetesRepository {
 
-    override suspend fun getNameSpaceList(): List<NameSpace> = withContext(Dispatchers.IO) {
-        api.getNameSpaceList().map { it.toDomainModel() }
+    override suspend fun getDaemonSet(daemonSetName: String, namespace: String): DaemonSet = withContext(Dispatchers.IO) {
+        api.getDaemonSet(daemonSetName, namespace).toDomainModel()
     }
 
-    override suspend fun getPodList(nameSpace: NameSpace?): List<Pod> = withContext(Dispatchers.IO) {
-        api.getPodList(nameSpace?.name).map { it.toDomainModel() }
+    override suspend fun getDaemonSetList(namespace: String?): List<DaemonSet> = withContext(Dispatchers.IO) {
+        if (namespace != null) {
+            api.getDaemonSetList(namespace).items.map { it.toDomainModel() }
+        } else {
+            api.getDaemonSetListForAllNamespaces().items.map { it.toDomainModel() }
+        }
     }
 
-    override suspend fun getPod(nameSpace: NameSpace, podName: String): Pod = withContext(Dispatchers.IO) {
-        api.getPod(nameSpace.name, podName).toDomainModel()
+    override suspend fun createDaemonSet(yaml: String, namespace: String): DaemonSet = withContext(Dispatchers.IO) {
+        api.createDaemonSet(namespace, Yaml.load(yaml) as V1beta1DaemonSet).toDomainModel()
     }
 
-    private fun V1Namespace.toDomainModel() = NameSpace(
-        metadata.namespace
-    )
+    override suspend fun replaceDaemonSet(name: String, yaml: String, namespace: String): DaemonSet = withContext(Dispatchers.IO) {
+        api.replaceDaemonSet(name, namespace, Yaml.load(yaml) as V1beta1DaemonSet).toDomainModel()
+    }
 
-    private fun V1Pod.toDomainModel() = Pod(
-        metadata.uid,
-        metadata.name
-    )
+    override suspend fun deleteDaemonSet(daemonSetName: String, namespace: String) = withContext(Dispatchers.IO) {
+        api.deleteDaemonSet(daemonSetName, namespace)
+    }
+
+    override suspend fun getDeployment(deploymentName: String, namespace: String): Deployment = withContext(Dispatchers.IO) {
+        api.getDeployment(deploymentName, namespace).toDomainModel()
+    }
+
+    override suspend fun getDeploymentList(namespace: String?): List<Deployment> = withContext(Dispatchers.IO) {
+        if (namespace != null) {
+            api.getDeploymentList(namespace).items.map { it.toDomainModel() }
+        } else {
+            api.getDeploymentListForAllNamespaces().items.map { it.toDomainModel() }
+        }
+    }
+
+    override suspend fun createDeployment(yaml: String, namespace: String): Deployment = withContext(Dispatchers.IO) {
+        api.createDeployment(namespace, Yaml.load(yaml) as ExtensionsV1beta1Deployment).toDomainModel()
+    }
+
+    override suspend fun replaceDeployment(name: String, yaml: String, namespace: String): Deployment = withContext(Dispatchers.IO) {
+        api.replaceDeployment(name, namespace, Yaml.load(yaml) as ExtensionsV1beta1Deployment).toDomainModel()
+    }
+
+    override suspend fun deleteDeployment(deploymentName: String, namespace: String) = withContext(Dispatchers.IO) {
+        api.deleteDeployment(deploymentName, namespace)
+    }
+
+    override suspend fun getNamespace(namespaceName: String): Namespace = withContext(Dispatchers.IO) {
+        api.getNamespace(namespaceName).toDomainModel()
+    }
+
+    override suspend fun getNamespaceList(): List<Namespace> = withContext(Dispatchers.IO) {
+        api.getNamespaceList().items.map { it.toDomainModel() }
+    }
+
+    override suspend fun createNamespace(yaml: String): Namespace = withContext(Dispatchers.IO) {
+        api.createNamespace(Yaml.load(yaml) as V1Namespace).toDomainModel()
+    }
+
+    override suspend fun replaceNamespace(name: String, yaml: String): Namespace = withContext(Dispatchers.IO) {
+        api.replaceNamespace(name, Yaml.load(yaml) as V1Namespace).toDomainModel()
+    }
+
+    override suspend fun deleteNamespace(namespaceName: String) = withContext(Dispatchers.IO) {
+        api.deleteNamespace(namespaceName)
+    }
+
+    override suspend fun getNode(nodeName: String): Node = withContext(Dispatchers.IO) {
+        api.getNode(nodeName).toDomainModel()
+    }
+
+    override suspend fun getNodeList(): List<Node> = withContext(Dispatchers.IO) {
+        api.getNodeList().items.map { it.toDomainModel() }
+    }
+
+    override suspend fun deleteNode(nodeName: String) = withContext(Dispatchers.IO) {
+        api.deleteNode(nodeName)
+    }
+
+    override suspend fun getPod(podName: String, namespace: String): Pod = withContext(Dispatchers.IO) {
+        api.getPod(podName, namespace).toDomainModel()
+    }
+
+    override suspend fun getPodList(namespace: String?): List<Pod> = withContext(Dispatchers.IO) {
+        if (namespace != null) {
+            api.getPodList(namespace).items.map { it.toDomainModel() }
+        } else {
+            api.getPodListForAllNamespaces().items.map { it.toDomainModel() }
+        }
+    }
+
+    override suspend fun createPod(yaml: String, namespace: String): Pod = withContext(Dispatchers.IO) {
+        api.createPod(namespace, Yaml.load(yaml) as V1Pod).toDomainModel()
+    }
+
+    override suspend fun replacePod(name: String, yaml: String, namespace: String): Pod = withContext(Dispatchers.IO) {
+        api.replacePod(name, namespace, Yaml.load(yaml) as V1Pod).toDomainModel()
+    }
+
+    override suspend fun deletePod(podName: String, namespace: String) = withContext(Dispatchers.IO) {
+        api.deletePod(podName, namespace)
+    }
+
+    override suspend fun getReplicaSet(replicaSetName: String, namespace: String): ReplicaSet = withContext(Dispatchers.IO) {
+        api.getReplicaSet(replicaSetName, namespace).toDomainModel()
+    }
+
+    override suspend fun getReplicaSetList(namespace: String?): List<ReplicaSet> = withContext(Dispatchers.IO) {
+        if (namespace != null) {
+            api.getReplicaSetList(namespace).items.map { it.toDomainModel() }
+        } else {
+            api.getReplicaSetListForAllNamespaces().items.map { it.toDomainModel() }
+        }
+    }
+
+    override suspend fun createReplicaSet(yaml: String, namespace: String): ReplicaSet = withContext(Dispatchers.IO) {
+        api.createReplicaSet(namespace, Yaml.load(yaml) as V1ReplicaSet).toDomainModel()
+    }
+
+    override suspend fun replaceReplicaSet(name: String, yaml: String, namespace: String): ReplicaSet = withContext(Dispatchers.IO) {
+        api.replaceReplicaSet(name, namespace, Yaml.load(yaml) as V1ReplicaSet).toDomainModel()
+    }
+
+    override suspend fun deleteReplicaSet(replicaSetName: String, namespace: String) = withContext(Dispatchers.IO) {
+        api.deleteReplicaSet(replicaSetName, namespace)
+    }
+
+    override suspend fun getSecret(secretName: String, namespace: String): Secret = withContext(Dispatchers.IO) {
+        api.getSecret(secretName, namespace).toDomainModel()
+    }
+
+    override suspend fun getSecretList(namespace: String?): List<Secret> = withContext(Dispatchers.IO) {
+        if (namespace != null) {
+            api.getSecretList(namespace).items.map { it.toDomainModel() }
+        } else {
+            api.getSecretListForAllNamespaces().items.map { it.toDomainModel() }
+        }
+    }
+
+    override suspend fun createSecret(yaml: String, namespace: String): Secret = withContext(Dispatchers.IO) {
+        api.createSecret(namespace, Yaml.load(yaml) as V1Secret).toDomainModel()
+    }
+
+    override suspend fun replaceSecret(name: String, yaml: String, namespace: String): Secret = withContext(Dispatchers.IO) {
+        api.replaceSecret(name, namespace, Yaml.load(yaml) as V1Secret).toDomainModel()
+    }
+
+    override suspend fun deleteSecret(secretName: String, namespace: String) = withContext(Dispatchers.IO) {
+        api.deleteSecret(secretName, namespace)
+    }
+
+    override suspend fun getService(serviceName: String, namespace: String): Service = withContext(Dispatchers.IO) {
+        api.getService(serviceName, namespace).toDomainModel()
+    }
+
+    override suspend fun getServiceList(namespace: String?): List<Service> = withContext(Dispatchers.IO) {
+        if (namespace != null) {
+            api.getServiceList(namespace).items.map { it.toDomainModel() }
+        } else {
+            api.getServiceListForAllNamespaces().items.map { it.toDomainModel() }
+        }
+    }
+
+    override suspend fun createService(yaml: String, namespace: String): Service = withContext(Dispatchers.IO) {
+        api.createService(namespace, Yaml.load(yaml) as V1Service).toDomainModel()
+    }
+
+    override suspend fun replaceService(name: String, yaml: String, namespace: String): Service = withContext(Dispatchers.IO) {
+        api.replaceService(name, namespace, Yaml.load(yaml) as V1Service).toDomainModel()
+    }
+
+    override suspend fun deleteService(serviceName: String, namespace: String) = withContext(Dispatchers.IO) {
+        api.deleteService(serviceName, namespace)
+    }
+
+    override suspend fun getStatefulSet(statefulSetName: String, namespace: String): StatefulSet = withContext(Dispatchers.IO) {
+        api.getStatefulSet(statefulSetName, namespace).toDomainModel()
+    }
+
+    override suspend fun getStatefulSetList(namespace: String?): List<StatefulSet> = withContext(Dispatchers.IO) {
+        if (namespace != null) {
+            api.getStatefulSetList(namespace).items.map { it.toDomainModel() }
+        } else {
+            api.getStatefulSetListForAllNamespaces().items.map { it.toDomainModel() }
+        }
+    }
+
+    override suspend fun createStatefulSet(yaml: String, namespace: String): StatefulSet = withContext(Dispatchers.IO) {
+        api.createStatefulSet(namespace, Yaml.load(yaml) as V1StatefulSet).toDomainModel()
+    }
+
+    override suspend fun replaceStatefulSet(name: String, yaml: String, namespace: String): StatefulSet = withContext(Dispatchers.IO) {
+        api.replaceStatefulSet(name, namespace, Yaml.load(yaml) as V1StatefulSet).toDomainModel()
+    }
+
+    override suspend fun deleteStatefulSet(statefulSetName: String, namespace: String) = withContext(Dispatchers.IO) {
+        api.deleteStatefulSet(statefulSetName, namespace)
+    }
 }

--- a/presenter/src/main/kotlin/org/jaram/jubaky/presenter/JubakyServer.kt
+++ b/presenter/src/main/kotlin/org/jaram/jubaky/presenter/JubakyServer.kt
@@ -10,8 +10,10 @@ import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
 import org.jaram.jubaky.ext.getInt
 import org.jaram.jubaky.presenter.router.dev
+import org.jaram.jubaky.presenter.router.infra
 import org.jaram.jubaky.presenter.router.user
 import org.jaram.jubaky.service.JenkinsService
+import org.jaram.jubaky.service.KubernetesService
 import org.jaram.jubaky.service.TokenService
 import org.jaram.jubaky.service.UserService
 import org.slf4j.LoggerFactory
@@ -22,7 +24,8 @@ class JubakyServer(
     private val properties: Properties,
     userService: UserService,
     tokenService: TokenService,
-    jenkinsService: JenkinsService
+    jenkinsService: JenkinsService,
+    kubernetesService: KubernetesService
 ) {
 
     val port = properties.getInt("SERVICE_PORT") ?: 8080
@@ -39,6 +42,7 @@ class JubakyServer(
                 get("/health") { call.respondText("ok") }
                 route("/user") { user(userService) }
                 route("/dev") { dev(jenkinsService) }
+                route("/infra") { infra(kubernetesService) }
             }
         }
     }

--- a/presenter/src/main/kotlin/org/jaram/jubaky/presenter/router/InfraRouter.kt
+++ b/presenter/src/main/kotlin/org/jaram/jubaky/presenter/router/InfraRouter.kt
@@ -1,0 +1,441 @@
+package org.jaram.jubaky.presenter.router
+
+import io.ktor.routing.*
+import org.jaram.jubaky.presenter.ext.*
+import org.jaram.jubaky.service.KubernetesService
+
+fun Route.infra(kubernetesService: KubernetesService) {
+    get("/") {
+        response(
+            "Kubernetes Service"
+        )
+    }
+
+    route("/daemonSet") {
+        get("/") {
+            response(
+                kubernetesService.getDaemonSetList()
+            )
+        }
+
+        get("/{namespace}/{name}") {
+            val daemonSetName = pathParam("name")
+            val namespaceName = pathParam("namespace", "default")
+
+            response(
+                kubernetesService.getDaemonSet(daemonSetName, namespaceName)
+            )
+        }
+
+        get("/{namespace}") {
+            val namespaceName = pathParam("namespace", "default")
+
+            response(
+                kubernetesService.getDaemonSetList(namespaceName)
+            )
+        }
+
+        post("/{namespace}") {
+            val namespaceName = pathParam("namespace", "default")
+            val yaml = bodyParam("yaml")
+
+            response(
+                kubernetesService.createDaemonSet(yaml, namespaceName)
+            )
+        }
+
+        put("/{namespace}/{name}") {
+            val namespaceName = pathParam("namespace", "default")
+            val objectName = pathParam("name")
+            val yaml = bodyParam("yaml")
+
+            response(
+                kubernetesService.replaceDaemonSet(objectName, yaml, namespaceName)
+            )
+        }
+
+        delete("/{namespace}/{name}") {
+            val daemonSetName = pathParam("name")
+            val namespaceName = pathParam("namespace", "default")
+
+            response(
+                kubernetesService.deleteDaemonSet(daemonSetName, namespaceName)
+            )
+        }
+    }
+
+    route("/deployment") {
+        get("/") {
+            response(
+                kubernetesService.getDeploymentList()
+            )
+        }
+
+        get("/{namespace}") {
+            val namespaceName = pathParam("namespace", "default")
+
+            response(
+                kubernetesService.getDeploymentList(namespaceName)
+            )
+        }
+
+        get("/{namespace}/{name}") {
+            val deploymentName = pathParam("name")
+            val namespaceName = pathParam("namespace", "default")
+
+            response(
+                kubernetesService.getDeployment(deploymentName, namespaceName)
+            )
+        }
+
+        post("/{namespace}") {
+            val namespaceName = pathParam("namespace", "default")
+            val yaml = bodyParam("yaml")
+
+            response(
+                kubernetesService.createDeployment(yaml, namespaceName)
+            )
+        }
+
+        put("/{namespace}/{name}") {
+            val namespaceName = pathParam("namespace", "default")
+            val objectName = pathParam("name")
+            val yaml = bodyParam("yaml")
+
+            response(
+                kubernetesService.replaceDeployment(objectName, yaml, namespaceName)
+            )
+        }
+
+        delete("/{namespace}/{name}") {
+            val deploymentName = pathParam("name")
+            val namespaceName = pathParam("namespace", "default")
+
+            response(
+                kubernetesService.deleteDeployment(deploymentName, namespaceName)
+            )
+        }
+    }
+
+    route("/namespace") {
+        get("/") {
+            response(
+                kubernetesService.getNamespaceList()
+            )
+        }
+
+        get("/{name}") {
+            val namespaceName = pathParam("name", "default")
+
+            response(
+                kubernetesService.getNamespace(namespaceName)
+            )
+        }
+
+        post("/") {
+            val yaml = bodyParam("yaml")
+
+            response(
+                kubernetesService.createNamespace(yaml)
+            )
+        }
+
+        put("/{name}") {
+            val namespaceName = pathParam("name", "default")
+            val yaml = bodyParam("yaml")
+
+            response(
+                kubernetesService.replaceNamespace(namespaceName, yaml)
+            )
+        }
+
+        delete("/{name}") {
+            val namespaceName = pathParam("name", "default")
+
+            response(
+                kubernetesService.deleteNamespace(namespaceName)
+            )
+        }
+    }
+
+    route("/node") {
+        get("/") {
+            response(
+                kubernetesService.getNodeList()
+            )
+        }
+
+        get("/{name}") {
+            val nodeName = pathParam("name")
+
+            response(
+                kubernetesService.getNode(nodeName)
+            )
+        }
+    }
+
+    route("/pod") {
+        get("/") {
+            response(
+                kubernetesService.getPodList()
+            )
+        }
+
+        get("/{namespace}") {
+            val namespaceName = pathParam("namespace", "default")
+
+            response(
+                kubernetesService.getPodList(namespaceName)
+            )
+        }
+
+        get("/{namespace}/{name}") {
+            val podName = pathParam("name")
+            val namespaceName = pathParam("namespace", "default")
+
+            response(
+                kubernetesService.getPod(podName, namespaceName)
+            )
+        }
+
+        post("/{namespace}") {
+            val namespaceName = pathParam("namespace", "default")
+            val yaml = bodyParam("yaml")
+
+            response(
+                kubernetesService.createPod(yaml, namespaceName)
+            )
+        }
+
+        put("/{namespace}/{name}") {
+            val namespaceName = pathParam("namespace", "default")
+            val objectName = pathParam("name")
+            val yaml = bodyParam("yaml")
+
+            response(
+                kubernetesService.replacePod(objectName, yaml, namespaceName)
+            )
+        }
+
+        delete("/{namespace}/{name}") {
+            val podName = pathParam("name")
+            val namespaceName = pathParam("namespace", "default")
+
+            response(
+                kubernetesService.deletePod(podName, namespaceName)
+            )
+        }
+    }
+
+    route("/replicaSet") {
+        get("/") {
+            response(
+                kubernetesService.getReplicaSetList()
+            )
+        }
+
+        get("/{namespace}") {
+            val namespaceName = pathParam("namespace", "default")
+
+            response(
+                kubernetesService.getReplicaSetList(namespaceName)
+            )
+        }
+
+        get("/{namespace}/{name}") {
+            val replicaSetName = pathParam("name")
+            val namespaceName = pathParam("namespace", "default")
+
+            response(
+                kubernetesService.getReplicaSet(replicaSetName, namespaceName)
+            )
+        }
+
+        post("/{namespace}") {
+            val namespaceName = pathParam("namespace", "default")
+            val yaml = bodyParam("yaml")
+
+            response(
+                kubernetesService.createReplicaSet(yaml, namespaceName)
+            )
+        }
+
+        put("/{namespace}/{name}") {
+            val namespaceName = pathParam("namespace", "default")
+            val objectName = pathParam("name")
+            val yaml = bodyParam("yaml")
+
+            response(
+                kubernetesService.replaceReplicaSet(objectName, yaml, namespaceName)
+            )
+        }
+
+        delete("/{namespace}/{name}") {
+            val replicaSetName = pathParam("name")
+            val namespaceName = pathParam("namespace", "default")
+
+            response(
+                kubernetesService.deleteReplicaSet(replicaSetName, namespaceName)
+            )
+        }
+    }
+
+    route("/secret") {
+        get("/") {
+            response(
+                kubernetesService.getSecretList()
+            )
+        }
+
+        get("/{namespace}") {
+            val namespaceName = pathParam("namespace", "default")
+
+            response(
+                kubernetesService.getSecretList(namespaceName)
+            )
+        }
+
+        get("/{namespace}/{name}") {
+            val secretName = pathParam("name")
+            val namespaceName = pathParam("namespace", "default")
+
+            response(
+                kubernetesService.getSecret(secretName, namespaceName)
+            )
+        }
+
+        post("/{namespace}") {
+            val namespaceName = pathParam("namespace", "default")
+            val yaml = bodyParam("yaml")
+
+            response(
+                kubernetesService.createSecret(yaml, namespaceName)
+            )
+        }
+
+        put("/{namespace}/{name}") {
+            val namespaceName = pathParam("namespace", "default")
+            val objectName = pathParam("name")
+            val yaml = bodyParam("yaml")
+
+            response(
+                kubernetesService.replaceSecret(objectName, yaml, namespaceName)
+            )
+        }
+
+        delete("/{namespace}/{name}") {
+            val secretName = pathParam("name")
+            val namespaceName = pathParam("namespace", "default")
+
+            response(
+                kubernetesService.deleteSecret(secretName, namespaceName)
+            )
+        }
+    }
+
+    route("/service") {
+        get("/") {
+            response(
+                kubernetesService.getServiceList()
+            )
+        }
+
+        get("/{namespace}") {
+            val namespaceName = pathParam("namespace", "default")
+
+            response(
+                kubernetesService.getServiceList(namespaceName)
+            )
+        }
+
+        get("/{namespace}/{name}") {
+            val serviceName = pathParam("name")
+            val namespaceName = pathParam("namespace", "default")
+
+            response(
+                kubernetesService.getService(serviceName, namespaceName)
+            )
+        }
+
+        post("/{namespace}") {
+            val namespaceName = pathParam("namespace", "default")
+            val yaml = bodyParam("yaml")
+
+            response(
+                kubernetesService.createService(yaml, namespaceName)
+            )
+        }
+
+        put("/{namespace}/{name}") {
+            val namespaceName = pathParam("namespace", "default")
+            val objectName = pathParam("name")
+            val yaml = bodyParam("yaml")
+
+            response(
+                kubernetesService.replaceService(objectName, yaml, namespaceName)
+            )
+        }
+
+        delete("/{namespace}/{name}") {
+            val serviceName = pathParam("name")
+            val namespaceName = pathParam("namespace", "default")
+
+            response(
+                kubernetesService.deleteService(serviceName, namespaceName)
+            )
+        }
+    }
+
+    route("/statefulSet") {
+        get("/") {
+            response(
+                kubernetesService.getStatefulSetList()
+            )
+        }
+
+        get("/{namespace}") {
+            val namespaceName = pathParam("namespace", "default")
+
+            response(
+                kubernetesService.getStatefulSetList(namespaceName)
+            )
+        }
+
+        get("/{namespace}/{name}") {
+            val statefulSetName = pathParam("name")
+            val namespaceName = pathParam("namespace", "default")
+
+            response(
+                kubernetesService.getStatefulSet(statefulSetName, namespaceName)
+            )
+        }
+
+        post("/{namespace}") {
+            val namespaceName = pathParam("namespace", "default")
+            val yaml = bodyParam("yaml")
+
+            response(
+                kubernetesService.createStatefulSet(yaml, namespaceName)
+            )
+        }
+
+        put("/{namespace}/{name}") {
+            val namespaceName = pathParam("namespace", "default")
+            val objectName = pathParam("name")
+            val yaml = bodyParam("yaml")
+
+            response(
+                kubernetesService.replaceStatefulSet(objectName, yaml, namespaceName)
+            )
+        }
+
+        delete("/") {
+            val statefulSetName = queryParam("name")
+            val namespaceName = pathParam("namespace", "default")
+
+            response(
+                kubernetesService.deleteStatefulSet(statefulSetName, namespaceName)
+            )
+        }
+    }
+}


### PR DESCRIPTION
Add kubernetes client communicated with the Kubernetes API

- daemonSet
 - get :: Get daemonSet
 - getList :: Get daemonSetList
 - create :: Create daemonSet
 - replace :: Replace daemonSet
 - delete :: Delete daemonSet
- deployment
 - get :: Get deployment
 - getList :: Get deploymentList
 - create :: Create deployment
 - replace :: Replace deployment
 - delete :: Delete deployment
- namespace
 - get :: Get namespace
 - getList :: Get namespaceList
 - create :: Create namespace
 - replace :: Replace namespace
 - delete :: Delete namespace
- node
 - get :: Get node
 - getList :: Get nodeList
- pod
 - get :: Get pod
 - getList :: Get podList
 - create :: Create pod
 - replace :: Replace pod
 - delete :: Delete pod
- replicaSet
 - get :: Get replicaSet
 - getList :: Get replicaSetList
 - create :: Create replicaSet
 - replace :: Replace replicaSet
 - delete :: Delete replicaSet
- secret
 - get :: Get secret
 - getList :: Get secretList
 - create :: Create secret
 - replace :: Replace secret
 - delete :: Delete secret
- service
 - get :: Get service
 - getList :: Get serviceList
 - create :: Create service
 - replace :: Replace service
 - delete :: Delete service
- statefulSet
 - get :: Get statefulSet
 - getList :: Get statefulSetList
 - create :: Create statefulSet
 - replace :: Replace statefulSet
 - delete :: Delete statefulSet

(19.08.15)